### PR TITLE
fix: context-aware back navigation from Step View to Job detail

### DIFF
--- a/.kiro/specs/nav-jobs-to-steps/.config.kiro
+++ b/.kiro/specs/nav-jobs-to-steps/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "23c6b8b2-fe4e-4178-b107-632690334aa9", "workflowType": "design-first", "specType": "feature"}

--- a/.kiro/specs/nav-jobs-to-steps/design.md
+++ b/.kiro/specs/nav-jobs-to-steps/design.md
@@ -1,0 +1,139 @@
+# Nav Jobs-to-Steps Back Arrow Bugfix Design
+
+## Overview
+
+When a user navigates from a Job detail page (`/jobs/:id`) to a Step View page (`/parts/step/:stepId`), the back arrow on the Step View page always directs them to `/parts` (the Parts list) instead of back to the Job detail page they came from. The fix will make the back navigation context-aware by passing the referrer route as a query parameter, so the Step View page can return the user to their actual origin.
+
+## Glossary
+
+- **Bug_Condition (C)**: The user arrived at the Step View page from the Job detail page (not from the Parts list), and the back arrow incorrectly navigates to `/parts`
+- **Property (P)**: The back arrow should navigate to the page the user came from — `/jobs/:id` when arriving from Job detail, `/parts` when arriving from Parts list
+- **Preservation**: Navigation from the Parts list to Step View must continue to show "Back to Parts" linking to `/parts`. All other Step View functionality (advancement, serial creation, operator selection, prev/next step navigation) must remain unchanged.
+- **Step View page**: `app/pages/parts/step/[stepId].vue` — the page that displays a single process step with advancement or serial creation UI
+- **Job detail page**: `app/pages/jobs/[id].vue` — the tabbed job view with routing, serial numbers, and step navigation via StepTracker
+- **Parts View page**: `app/pages/parts/index.vue` — the list of all active parts grouped by job/step
+- **`onStepClick`**: The function in `app/pages/jobs/[id].vue` that calls `navigateTo('/parts/step/${stepId}')` when a step is clicked in the StepTracker
+
+## Bug Details
+
+### Bug Condition
+
+The bug manifests when a user clicks a step in the Job detail page's StepTracker component, which navigates them to `/parts/step/:stepId`. The Step View page has a hardcoded `<NuxtLink to="/parts">` back arrow that always points to the Parts list, regardless of where the user navigated from.
+
+**Formal Specification:**
+```
+FUNCTION isBugCondition(input)
+  INPUT: input of type { currentRoute: Route, previousRoute: Route | null }
+  OUTPUT: boolean
+  
+  RETURN input.currentRoute.path MATCHES '/parts/step/:stepId'
+         AND input.previousRoute IS NOT NULL
+         AND input.previousRoute.path MATCHES '/jobs/:id'
+         AND backArrowDestination(input.currentRoute) == '/parts'
+END FUNCTION
+```
+
+### Examples
+
+- User is on `/jobs/JOB-abc123`, clicks step "Milling" in StepTracker → navigates to `/parts/step/STEP-xyz`. Back arrow goes to `/parts` instead of `/jobs/JOB-abc123`. **Expected**: Back arrow goes to `/jobs/JOB-abc123`.
+- User is on `/jobs/JOB-def456`, clicks step "Inspection" → navigates to `/parts/step/STEP-uvw`. Back arrow goes to `/parts` instead of `/jobs/JOB-def456`. **Expected**: Back arrow goes to `/jobs/JOB-def456`.
+- User is on `/parts` (Parts list), clicks a job group → navigates to `/parts/step/STEP-xyz`. Back arrow goes to `/parts`. **Expected**: Back arrow goes to `/parts` (this case already works correctly).
+- User navigates directly to `/parts/step/STEP-xyz` via URL. Back arrow goes to `/parts`. **Expected**: Back arrow goes to `/parts` (sensible default when no referrer context).
+
+## Expected Behavior
+
+### Preservation Requirements
+
+**Unchanged Behaviors:**
+- Navigation from Parts list (`/parts`) to Step View must continue to show "Back to Parts" linking to `/parts`
+- Direct URL access to Step View must default to "Back to Parts" linking to `/parts`
+- All Step View functionality: advancement panel, serial creation panel, operator selection, prev/next step navigation, notes display
+- All Job detail page functionality: StepTracker clicks, tab switching, path editing, Jira push
+- Parts list page: search, job selection, navigation to Step View
+- The `handleCancel` function in Step View that navigates to `/parts`
+
+**Scope:**
+All inputs that do NOT involve the back arrow navigation on the Step View page should be completely unaffected by this fix. This includes:
+- Step advancement and serial creation workflows
+- Operator identity selection
+- Prev/Next step navigation within Step View
+- All Job detail page interactions
+- All Parts list page interactions
+
+## Hypothesized Root Cause
+
+Based on the bug description, the root cause is straightforward:
+
+1. **Hardcoded back link in Step View**: The `<NuxtLink to="/parts">` in `app/pages/parts/step/[stepId].vue` is hardcoded to always point to `/parts`. There is no mechanism to detect or remember where the user navigated from.
+
+2. **No referrer context passed during navigation**: The `onStepClick` function in `app/pages/jobs/[id].vue` calls `navigateTo('/parts/step/${stepId}')` without passing any query parameter or state indicating the origin page.
+
+3. **`handleCancel` also hardcoded**: The `handleCancel` function in Step View calls `navigateTo('/parts')`, which should also respect the referrer context.
+
+## Correctness Properties
+
+Property 1: Bug Condition - Back Arrow Returns to Job Detail Page
+
+_For any_ navigation from a Job detail page (`/jobs/:id`) to a Step View page (`/parts/step/:stepId`), the back arrow on the Step View page SHALL navigate the user back to the Job detail page (`/jobs/:id`) they came from, and the back label SHALL read "Back to Job".
+
+**Validates: Requirements 2.1, 2.2**
+
+Property 2: Preservation - Default Back Navigation to Parts
+
+_For any_ navigation to the Step View page that did NOT originate from a Job detail page (e.g., from Parts list, direct URL, or any other source), the back arrow SHALL continue to navigate to `/parts` with the label "Back to Parts", preserving the existing default behavior.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+## Fix Implementation
+
+### Changes Required
+
+Assuming our root cause analysis is correct:
+
+**File**: `app/pages/jobs/[id].vue`
+
+**Function**: `onStepClick`
+
+**Specific Changes**:
+1. **Pass referrer query parameter**: Modify `onStepClick` to include a `from` query parameter with the current job route:
+   ```
+   navigateTo(`/parts/step/${stepId}?from=${encodeURIComponent(`/jobs/${jobId}`)}`)
+   ```
+
+**File**: `app/pages/parts/step/[stepId].vue`
+
+**Specific Changes**:
+2. **Read referrer from query**: Extract the `from` query parameter from the route to determine the back navigation target.
+
+3. **Compute back link destination**: Create a computed property that returns the `from` query value if present and valid (starts with `/jobs/`), otherwise defaults to `/parts`.
+
+4. **Compute back link label**: Create a computed property that returns "Back to Job" when the referrer is a job page, or "Back to Parts" otherwise.
+
+5. **Update back arrow NuxtLink**: Replace the hardcoded `to="/parts"` with the computed back destination.
+
+6. **Update handleCancel**: Make `handleCancel` navigate to the computed back destination instead of hardcoded `/parts`.
+
+7. **Propagate `from` on prev/next step navigation**: When the user clicks Prev/Next step buttons, the `from` query parameter should be preserved so the back arrow context is maintained across step-to-step navigation within the same session.
+
+## Testing Strategy
+
+Testing follows the project's existing patterns: Vitest + `fast-check` for property-based tests, pure function unit tests, no component rendering.
+
+### Unit Tests (`tests/unit/composables/`)
+
+Extract the back-navigation logic into a pure helper (e.g., `resolveBackNavigation(fromQuery)`) and test it directly:
+
+- Valid job origin: `resolveBackNavigation('/jobs/JOB-123')` → `{ to: '/jobs/JOB-123', label: 'Back to Job' }`
+- No `from` param: `resolveBackNavigation(undefined)` → `{ to: '/parts', label: 'Back to Parts' }`
+- Invalid `from` values (e.g., `/settings`, `javascript:alert(1)`, empty string) → fallback to `/parts`
+- `onStepClick` builds URL with `?from=` query parameter
+
+### Property-Based Tests (`tests/properties/`)
+
+One property file: `backNavigation.property.test.ts`
+
+**Property 1 — Fix**: For any valid job path (`/jobs/{id}`), `resolveBackNavigation` returns that path with label "Back to Job".
+
+**Property 2 — Preservation**: For any string that does NOT start with `/jobs/`, `resolveBackNavigation` returns `/parts` with label "Back to Parts".
+
+Uses `fast-check` with `fc.string()` / `fc.uuid()` arbitraries, 100+ iterations per property.

--- a/.kiro/specs/nav-jobs-to-steps/requirements.md
+++ b/.kiro/specs/nav-jobs-to-steps/requirements.md
@@ -1,0 +1,72 @@
+# Requirements Document
+
+## Introduction
+
+This document captures the requirements for fixing the back-arrow navigation bug on the Step View page. Currently, when a user navigates from a Job detail page to a Step View page, the back arrow always directs them to `/parts` (the Parts list) instead of back to the Job detail page they came from. The fix makes back navigation context-aware by passing the referrer route as a query parameter, so the Step View page returns the user to their actual origin.
+
+## Glossary
+
+- **Step_View_Page**: The page at `/parts/step/:stepId` that displays a single process step with advancement or serial creation UI (`app/pages/parts/step/[stepId].vue`)
+- **Job_Detail_Page**: The tabbed job view at `/jobs/:id` with routing, serial numbers, and step navigation via StepTracker (`app/pages/jobs/[id].vue`)
+- **Parts_View_Page**: The list of all active parts grouped by job/step at `/parts` (`app/pages/parts/index.vue`)
+- **Back_Arrow**: The navigation element on the Step_View_Page that returns the user to a previous page
+- **From_Query_Parameter**: A URL query parameter (`from`) appended to the Step View URL to indicate the page the user navigated from
+- **Resolve_Back_Navigation**: A pure helper function that computes the back-arrow destination and label based on the From_Query_Parameter value
+- **StepTracker**: The component on the Job_Detail_Page that displays process steps and allows clicking to navigate to the Step_View_Page
+
+## Requirements
+
+### Requirement 1: Pass Referrer Context on Navigation from Job Detail
+
+**User Story:** As a user viewing a Job detail page, I want the navigation to Step View to include referrer context, so that the Step View page knows where I came from.
+
+#### Acceptance Criteria
+
+1. WHEN a user clicks a step in the StepTracker on the Job_Detail_Page, THE Job_Detail_Page SHALL navigate to the Step_View_Page with a From_Query_Parameter containing the current Job_Detail_Page path (e.g., `/parts/step/:stepId?from=/jobs/:id`)
+2. THE Job_Detail_Page SHALL URL-encode the From_Query_Parameter value to ensure safe transmission of the referrer path
+
+### Requirement 2: Context-Aware Back Arrow on Step View
+
+**User Story:** As a user who arrived at the Step View from a Job detail page, I want the back arrow to return me to that Job detail page, so that I can continue reviewing the job without losing my place.
+
+#### Acceptance Criteria
+
+1. WHEN the From_Query_Parameter contains a valid Job_Detail_Page path (starting with `/jobs/`), THE Step_View_Page SHALL set the Back_Arrow destination to that Job_Detail_Page path
+2. WHEN the From_Query_Parameter contains a valid Job_Detail_Page path, THE Step_View_Page SHALL display the Back_Arrow label as "Back to Job"
+3. WHEN the From_Query_Parameter is absent, empty, or contains an invalid path, THE Resolve_Back_Navigation function SHALL return `/parts` as the destination and "Back to Parts" as the label
+
+### Requirement 3: Preserve Default Back Navigation
+
+**User Story:** As a user who arrived at the Step View from the Parts list or via direct URL, I want the back arrow to continue taking me to the Parts list, so that existing navigation behavior is unchanged.
+
+#### Acceptance Criteria
+
+1. WHEN a user navigates from the Parts_View_Page to the Step_View_Page, THE Step_View_Page SHALL display the Back_Arrow linking to `/parts` with the label "Back to Parts"
+2. WHEN a user accesses the Step_View_Page directly via URL without a From_Query_Parameter, THE Step_View_Page SHALL display the Back_Arrow linking to `/parts` with the label "Back to Parts"
+3. WHEN the From_Query_Parameter contains a value that does not start with `/jobs/`, THE Resolve_Back_Navigation function SHALL return `/parts` as the destination and "Back to Parts" as the label
+
+### Requirement 4: Cancel Action Respects Referrer Context
+
+**User Story:** As a user on the Step View page, I want the cancel action to return me to the same page as the back arrow, so that navigation is consistent.
+
+#### Acceptance Criteria
+
+1. WHEN the user triggers the cancel action on the Step_View_Page, THE Step_View_Page SHALL navigate to the same destination as the Back_Arrow (the value computed by Resolve_Back_Navigation)
+
+### Requirement 5: Preserve Referrer Context Across Step Navigation
+
+**User Story:** As a user navigating between steps using Prev/Next buttons on the Step View page, I want the back arrow to continue pointing to my original referrer page, so that I can return to where I started after browsing multiple steps.
+
+#### Acceptance Criteria
+
+1. WHEN the user clicks a Prev or Next step button on the Step_View_Page, THE Step_View_Page SHALL propagate the current From_Query_Parameter to the new Step_View_Page URL
+2. WHEN the From_Query_Parameter is propagated across step navigation, THE Step_View_Page SHALL preserve the original referrer context for the Back_Arrow
+
+### Requirement 6: Input Validation for Referrer Parameter
+
+**User Story:** As a developer, I want the referrer parameter to be validated, so that only safe and expected values are used for navigation.
+
+#### Acceptance Criteria
+
+1. THE Resolve_Back_Navigation function SHALL only accept From_Query_Parameter values that start with `/jobs/` as valid job referrer paths
+2. IF the From_Query_Parameter contains a value that does not start with `/jobs/` (e.g., external URLs, `javascript:` URIs, or arbitrary paths), THEN THE Resolve_Back_Navigation function SHALL fall back to `/parts` as the destination

--- a/.kiro/specs/nav-jobs-to-steps/tasks.md
+++ b/.kiro/specs/nav-jobs-to-steps/tasks.md
@@ -1,0 +1,53 @@
+# Implementation Plan: Nav Jobs-to-Steps Back Arrow Bugfix
+
+## Overview
+
+Fix the back-arrow navigation on the Step View page so it returns to the Job detail page when the user navigated from there, instead of always going to `/parts`. The approach uses a `from` query parameter to pass referrer context, a pure helper function to resolve the back destination, and propagation of the `from` param across prev/next step navigation.
+
+## Tasks
+
+- [x] 1. Create the `resolveBackNavigation` helper and its tests
+  - [x] 1.1 Create `app/utils/resolveBackNavigation.ts` with a pure function that accepts a `from` query value and returns `{ to: string, label: string }`
+    - If `from` starts with `/jobs/`, return `{ to: from, label: 'Back to Job' }`
+    - Otherwise (undefined, empty, invalid, external URLs, `javascript:` URIs), return `{ to: '/parts', label: 'Back to Parts' }`
+    - _Requirements: 2.3, 3.3, 6.1, 6.2_
+
+  - [x] 1.2 Write property test `tests/properties/backNavigation.property.test.ts`
+    - **Property 1: Bug Condition — Back Arrow Returns to Job Detail Page**
+    - For any valid job path (`/jobs/{id}`), `resolveBackNavigation` returns that path with label "Back to Job"
+    - **Validates: Requirements 2.1, 2.2**
+
+  - [x] 1.3 Write property test for default fallback in `tests/properties/backNavigation.property.test.ts`
+    - **Property 2: Preservation — Default Back Navigation to Parts**
+    - For any string that does NOT start with `/jobs/`, `resolveBackNavigation` returns `/parts` with label "Back to Parts"
+    - **Validates: Requirements 3.1, 3.2, 3.3, 6.1, 6.2**
+
+  - [x] 1.4 Write unit test `tests/unit/utils/resolveBackNavigation.test.ts`
+    - Test specific examples: valid job path, undefined, empty string, external URL, `javascript:alert(1)`, `/settings`, `/parts`
+    - _Requirements: 2.3, 3.3, 6.1, 6.2_
+
+- [x] 2. Update Step View page to use context-aware back navigation
+  - [x] 2.1 Update `app/pages/parts/step/[stepId].vue` to read the `from` query parameter and use `resolveBackNavigation` to compute the back-arrow destination and label
+    - Replace the hardcoded `<NuxtLink to="/parts">` back arrow with the computed destination and label
+    - Update `handleCancel` to navigate to the computed destination instead of hardcoded `/parts`
+    - _Requirements: 2.1, 2.2, 2.3, 3.1, 3.2, 4.1_
+
+  - [x] 2.2 Propagate the `from` query parameter on Prev/Next step navigation in `app/pages/parts/step/[stepId].vue`
+    - Update the Prev and Next `<UButton>` `:to` bindings to append `?from=...` when the `from` query param is present
+    - Also propagate `from` on the 404 "Back to Parts" button when a `from` param exists
+    - _Requirements: 5.1, 5.2_
+
+- [x] 3. Update Job detail page to pass referrer context
+  - [x] 3.1 Update `onStepClick` in `app/pages/jobs/[id].vue` to append `?from=/jobs/:id` to the Step View URL
+    - Use `encodeURIComponent` for the `from` value
+    - _Requirements: 1.1, 1.2_
+
+- [x] 4. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- `resolveBackNavigation` is placed in `app/utils/` so it is auto-imported by Nuxt (no explicit import needed in Vue files)
+- Property tests use `fast-check` with 100+ iterations per property, following existing project patterns
+- Each task references specific requirements for traceability

--- a/AI-MAP.md
+++ b/AI-MAP.md
@@ -7,7 +7,7 @@
 
 Shop Planr (package name: `shop-erp`) is a job routing and ERP application for machine shops. It tracks production orders (Jobs) through multi-path routing of parts across sequential Process Steps, with serial number management, certificate traceability, progress visualization, and optional Jira integration. Built as a full-stack Nuxt 4 app with SQLite persistence.
 
-**Status**: All features implemented. Job lifecycle management added (scrap, force-complete, flexible advancement, step overrides, waivers, BOM versioning, process/location libraries). Dedicated job creation/edit pages. Serial detail page Routing tab reorganized into SectionCard sections. First-step serial creation panel (SerialCreationPanel) for operator work queue. Operator view redesigned: monolithic operator.vue split into Parts View (/parts), Step View (/parts/step/[stepId]), and Operator Work Queue (/queue). Inline note creation on serial detail page. Step overflow UX: StepTracker uses flex-wrap instead of horizontal scroll, compact step cards, condensed serial counts. Nav page toggles: Settings → Page Visibility tab to hide/show sidebar pages, with route middleware guard and reactive sidebar filtering. Step 1 disabled-after-advance bugfix: zero-serial steps return 200 with partCount:0 instead of 404; first steps always visible in Parts View; prev/next step navigation; deduplicated step headers. Page toggle refresh bugfix: `app/plugins/settings.ts` plugin fetches settings once on app init so sidebar filtering and route middleware have correct toggle state on every page load (no flash, no stale fallback). 103 property-based tests (66 correctness properties), 51 integration tests, 689 tests passing across 114 files. Full frontend with lifecycle dialogs, configuration panels, and audit filters.
+**Status**: All features implemented. Job lifecycle management added (scrap, force-complete, flexible advancement, step overrides, waivers, BOM versioning, process/location libraries). Dedicated job creation/edit pages. Serial detail page Routing tab reorganized into SectionCard sections. First-step serial creation panel (SerialCreationPanel) for operator work queue. Operator view redesigned: monolithic operator.vue split into Parts View (/parts), Step View (/parts/step/[stepId]), and Operator Work Queue (/queue). Inline note creation on serial detail page. Step overflow UX: StepTracker uses flex-wrap instead of horizontal scroll, compact step cards, condensed serial counts. Nav page toggles: Settings → Page Visibility tab to hide/show sidebar pages, with route middleware guard and reactive sidebar filtering. Step 1 disabled-after-advance bugfix: zero-serial steps return 200 with partCount:0 instead of 404; first steps always visible in Parts View; prev/next step navigation; deduplicated step headers. Page toggle refresh bugfix: `app/plugins/settings.ts` plugin fetches settings once on app init so sidebar filtering and route middleware have correct toggle state on every page load (no flash, no stale fallback). 105 property-based tests (68 correctness properties), 51 integration tests, 700 tests passing across 116 files. Nav jobs-to-steps back arrow bugfix: Step View back arrow is context-aware via `from` query parameter, returning to Job detail when navigated from there. Full frontend with lifecycle dialogs, configuration panels, and audit filters.
 
 ## Tech Stack
 
@@ -38,6 +38,7 @@ app/
     pageGuard.global.ts  → Global route middleware: blocks navigation to disabled pages, redirects to /
   utils/
     pageToggles.ts       → Re-exports DEFAULT_PAGE_TOGGLES, ROUTE_TOGGLE_MAP, isPageEnabled() for client-side auto-import
+    resolveBackNavigation.ts → Pure helper: computes back-arrow destination/label from `from` query param (auto-imported)
   assets/css/
     main.css             → Tailwind imports + custom violet #8750FF scale + green scale
 server/
@@ -81,7 +82,7 @@ tests/
 | Dev server | `npm run dev` | Nuxt dev with HMR |
 | Build | `npm run build` | Production build to `.output/` |
 | Preview | `npm run preview` | Preview production build locally |
-| Test | `npm run test` | `vitest run` — 682 tests, 114 files |
+| Test | `npm run test` | `vitest run` — 700 tests, 116 files |
 | Test watch | `npm run test:watch` | `vitest` in watch mode |
 | Lint | `npm run lint` | ESLint with Nuxt config |
 | Typecheck | `npm run typecheck` | `nuxt typecheck` |

--- a/app/pages/jobs/[id].vue
+++ b/app/pages/jobs/[id].vue
@@ -75,8 +75,8 @@ const jiraPushAvailable = computed(() =>
 )
 
 function onStepClick(pathId: string, payload: { stepId: string, stepName: string, stepOrder: number }) {
-  // Navigate to step view for this step (advancement)
-  navigateTo(`/parts/step/${encodeURIComponent(payload.stepId)}`)
+  // Navigate to step view for this step (advancement), passing referrer context
+  navigateTo(`/parts/step/${encodeURIComponent(payload.stepId)}?from=${encodeURIComponent(`/jobs/${jobId}`)}`)
 }
 
 function onStepConfigure(pathId: string, payload: { stepId: string }) {

--- a/app/pages/parts/step/[stepId].vue
+++ b/app/pages/parts/step/[stepId].vue
@@ -3,6 +3,8 @@ import type { DropdownMenuItem } from '@nuxt/ui'
 
 const route = useRoute()
 const stepId = route.params.stepId as string
+const fromQuery = route.query.from as string | undefined
+const backNav = computed(() => resolveBackNavigation(fromQuery))
 
 const {
   job,
@@ -90,7 +92,7 @@ async function handleCreated(count: number) {
 }
 
 function handleCancel() {
-  navigateTo('/parts')
+  navigateTo(backNav.value.to)
 }
 
 onMounted(async () => {
@@ -103,11 +105,11 @@ onMounted(async () => {
   <div class="p-4 space-y-4 max-w-5xl">
     <!-- Back link -->
     <NuxtLink
-      to="/parts"
+      :to="backNav.to"
       class="inline-flex items-center gap-1 text-sm text-(--ui-text-muted) hover:text-(--ui-text-highlighted) transition-colors"
     >
       <UIcon name="i-lucide-arrow-left" class="size-4" />
-      Back to Parts
+      {{ backNav.label }}
     </NuxtLink>
 
     <!-- Loading state -->
@@ -130,10 +132,10 @@ onMounted(async () => {
         This step doesn't exist or has no active parts.
       </p>
       <UButton
-        to="/parts"
+        :to="backNav.to"
         size="sm"
         variant="soft"
-        label="Back to Parts"
+        :label="backNav.label"
         icon="i-lucide-arrow-left"
       />
     </div>
@@ -207,7 +209,7 @@ onMounted(async () => {
             icon="i-lucide-arrow-left"
             label="Prev"
             :disabled="job.stepOrder === 0"
-            :to="job.previousStepId ? `/parts/step/${job.previousStepId}` : undefined"
+            :to="job.previousStepId ? `/parts/step/${job.previousStepId}${fromQuery ? `?from=${encodeURIComponent(fromQuery)}` : ''}` : undefined"
           />
           <UButton
             size="xs"
@@ -215,7 +217,7 @@ onMounted(async () => {
             trailing-icon="i-lucide-arrow-right"
             label="Next"
             :disabled="job.isFinalStep"
-            :to="job.nextStepId ? `/parts/step/${job.nextStepId}` : undefined"
+            :to="job.nextStepId ? `/parts/step/${job.nextStepId}${fromQuery ? `?from=${encodeURIComponent(fromQuery)}` : ''}` : undefined"
           />
         </div>
       </div>
@@ -252,10 +254,10 @@ onMounted(async () => {
           Parts will appear here once they are advanced from the previous step.
         </p>
         <UButton
-          to="/parts"
+          :to="backNav.to"
           size="sm"
           variant="soft"
-          label="Back to Parts"
+          :label="backNav.label"
           icon="i-lucide-arrow-left"
         />
       </div>

--- a/app/utils/resolveBackNavigation.ts
+++ b/app/utils/resolveBackNavigation.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure helper that computes the back-arrow destination and label
+ * based on the `from` query parameter value.
+ *
+ * Placed in `app/utils/` for Nuxt auto-import.
+ */
+
+export interface BackNavigation {
+  to: string
+  label: string
+}
+
+export function resolveBackNavigation(from: string | undefined | null): BackNavigation {
+  if (typeof from === 'string' && from.startsWith('/jobs/')) {
+    return { to: from, label: 'Back to Job' }
+  }
+
+  return { to: '/parts', label: 'Back to Parts' }
+}

--- a/tests/properties/backNavigation.property.test.ts
+++ b/tests/properties/backNavigation.property.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Properties 1–2: resolveBackNavigation
+ *
+ * - Property 1: Bug Condition — Back Arrow Returns to Job Detail Page
+ * - Property 2: Preservation — Default Back Navigation to Parts
+ *
+ * **Validates: Requirements 2.1, 2.2, 3.1, 3.2, 3.3, 6.1, 6.2**
+ */
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import { resolveBackNavigation } from '~/app/utils/resolveBackNavigation'
+
+/** Arbitrary that produces a non-empty alphanumeric/dash/underscore job ID. */
+const arbJobId = fc.stringMatching(/^[A-Za-z0-9_-]+$/, { minLength: 1 })
+
+describe('Property 1: Bug Condition — Back Arrow Returns to Job Detail Page', () => {
+  /**
+   * **Validates: Requirements 2.1, 2.2**
+   *
+   * For any valid job path (`/jobs/{id}`), `resolveBackNavigation` returns
+   * that path with label "Back to Job".
+   */
+  it('returns the job path and "Back to Job" label for any /jobs/{id} input', () => {
+    fc.assert(
+      fc.property(arbJobId, (jobId) => {
+        const jobPath = `/jobs/${jobId}`
+        const result = resolveBackNavigation(jobPath)
+
+        expect(result.to).toBe(jobPath)
+        expect(result.label).toBe('Back to Job')
+      }),
+      { numRuns: 200 },
+    )
+  })
+})
+
+describe('Property 2: Preservation — Default Back Navigation to Parts', () => {
+  /**
+   * **Validates: Requirements 3.1, 3.2, 3.3, 6.1, 6.2**
+   *
+   * For any string that does NOT start with `/jobs/`, `resolveBackNavigation`
+   * returns `/parts` with label "Back to Parts".
+   */
+  it('returns /parts and "Back to Parts" for any string not starting with /jobs/', () => {
+    fc.assert(
+      fc.property(
+        fc.string().filter((s) => !s.startsWith('/jobs/')),
+        (input) => {
+          const result = resolveBackNavigation(input)
+
+          expect(result.to).toBe('/parts')
+          expect(result.label).toBe('Back to Parts')
+        },
+      ),
+      { numRuns: 200 },
+    )
+  })
+
+  it('returns /parts and "Back to Parts" for undefined input', () => {
+    const result = resolveBackNavigation(undefined)
+
+    expect(result.to).toBe('/parts')
+    expect(result.label).toBe('Back to Parts')
+  })
+
+  it('returns /parts and "Back to Parts" for empty string input', () => {
+    const result = resolveBackNavigation('')
+
+    expect(result.to).toBe('/parts')
+    expect(result.label).toBe('Back to Parts')
+  })
+})

--- a/tests/unit/utils/resolveBackNavigation.test.ts
+++ b/tests/unit/utils/resolveBackNavigation.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { resolveBackNavigation } from '~/app/utils/resolveBackNavigation'
+
+describe('resolveBackNavigation', () => {
+  it('returns job path and "Back to Job" for a valid job path', () => {
+    const result = resolveBackNavigation('/jobs/JOB-123')
+    expect(result).toEqual({ to: '/jobs/JOB-123', label: 'Back to Job' })
+  })
+
+  it('returns /parts and "Back to Parts" for undefined', () => {
+    const result = resolveBackNavigation(undefined)
+    expect(result).toEqual({ to: '/parts', label: 'Back to Parts' })
+  })
+
+  it('returns /parts and "Back to Parts" for empty string', () => {
+    const result = resolveBackNavigation('')
+    expect(result).toEqual({ to: '/parts', label: 'Back to Parts' })
+  })
+
+  it('returns /parts and "Back to Parts" for an external URL', () => {
+    const result = resolveBackNavigation('https://evil.com')
+    expect(result).toEqual({ to: '/parts', label: 'Back to Parts' })
+  })
+
+  it('returns /parts and "Back to Parts" for javascript: URI', () => {
+    const result = resolveBackNavigation('javascript:alert(1)')
+    expect(result).toEqual({ to: '/parts', label: 'Back to Parts' })
+  })
+
+  it('returns /parts and "Back to Parts" for /settings', () => {
+    const result = resolveBackNavigation('/settings')
+    expect(result).toEqual({ to: '/parts', label: 'Back to Parts' })
+  })
+
+  it('returns /parts and "Back to Parts" for /parts', () => {
+    const result = resolveBackNavigation('/parts')
+    expect(result).toEqual({ to: '/parts', label: 'Back to Parts' })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the back-arrow navigation bug on the Step View page. Previously, the back arrow always pointed to `/parts` regardless of where the user navigated from. Now it's context-aware — returning to the Job detail page when the user came from there. Relates to #1 

## Changes

- **`app/utils/resolveBackNavigation.ts`** — Pure helper that computes back-arrow destination and label from a `from` query param. Returns `/jobs/:id` with "Back to Job" for job referrers, falls back to `/parts` with "Back to Parts" for everything else (including undefined, empty, external URLs, `javascript:` URIs).

- **`app/pages/parts/step/[stepId].vue`** — Reads `from` query param, uses `resolveBackNavigation` for the back arrow, cancel action, 404 button, and waiting-for-prior-step button. Prev/Next step buttons propagate the `from` param.

- **`app/pages/jobs/[id].vue`** — `onStepClick` now appends `?from=/jobs/:id` (URL-encoded) when navigating to Step View.

## Tests

- 2 property tests (`backNavigation.property.test.ts`) — bug condition + preservation
- 7 unit tests (`resolveBackNavigation.test.ts`) — specific edge cases
- **700 total tests passing across 116 files**, zero regressions