### PR TITLE
fix: create data directory before CI smoke test

### DIFF
--- a/.github/workflows/deploy-only.yml
+++ b/.github/workflows/deploy-only.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Smoke test built output
         run: |
+          mkdir -p data
           node .output/server/index.mjs &
           SERVER_PID=$!
           sleep 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Smoke test built output
         run: |
+          mkdir -p data
           node .output/server/index.mjs &
           SERVER_PID=$!
           sleep 5


### PR DESCRIPTION
better-sqlite3 requires the parent directory to exist. In CI there is no ./data/ directory (gitignored, only present on the server via Docker volume mount). The throwaway DB is discarded when the runner shuts down.