### PR TITLE
fix: add EXIT trap to kill smoke test server on failure

### DIFF
--- a/.github/workflows/deploy-only.yml
+++ b/.github/workflows/deploy-only.yml
@@ -34,6 +34,7 @@ jobs:
           mkdir -p data
           node .output/server/index.mjs &
           SERVER_PID=$!
+          trap "kill $SERVER_PID 2>/dev/null" EXIT
           sleep 5
           echo "Checking frontend..."
           curl -sf http://localhost:3000 > /dev/null
@@ -41,7 +42,6 @@ jobs:
           echo "Checking API..."
           curl -sf http://localhost:3000/api/jobs > /dev/null
           echo "✅ API OK"
-          kill $SERVER_PID
 
       - name: Clean previous deploy artifacts
         uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
           mkdir -p data
           node .output/server/index.mjs &
           SERVER_PID=$!
+          trap "kill $SERVER_PID 2>/dev/null" EXIT
           sleep 5
           echo "Checking frontend..."
           curl -sf http://localhost:3000 > /dev/null
@@ -54,7 +55,6 @@ jobs:
           echo "Checking API..."
           curl -sf http://localhost:3000/api/jobs > /dev/null
           echo "✅ API OK"
-          kill $SERVER_PID
 
       - name: Clean previous deploy artifacts
         uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3


### PR DESCRIPTION
If curl fails the script exits before the explicit kill, leaving the Node process running for the rest of the CI job. A trap on EXIT ensures cleanup regardless of how the step exits.