### PR TITLE
fix: cleanup dead code and fix issues from step properties PR (#108)

### DIFF
--- a/.kiro/specs/step-properties-cleanup/.config.kiro
+++ b/.kiro/specs/step-properties-cleanup/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "2058fb78-4613-4017-a2f8-a21ab68f1c26", "workflowType": "requirements-first", "specType": "bugfix"}

--- a/.kiro/specs/step-properties-cleanup/bugfix.md
+++ b/.kiro/specs/step-properties-cleanup/bugfix.md
@@ -1,0 +1,45 @@
+# Bugfix Requirements Document
+
+## Introduction
+
+GitHub Issue #109 identifies one bug and three cleanup items introduced by the step properties PR (#108) and the add-note-to-parts PR (#107). The bug is a partial save failure in `StepPropertiesEditor` that leaves inconsistent state when one of two sequential PATCH requests fails. The cleanup items are: a dead `onStepAssigned` handler in `jobs/[id].vue`, an orphaned `StepAssignmentDropdown.vue` component with no remaining consumers, and empty strings being stored as location values in SQLite instead of NULLs.
+
+## Bug Analysis
+
+### Current Behavior (Defect)
+
+1.1 WHEN a user edits both assignee and location in StepPropertiesEditor and the assignee PATCH succeeds but the location PATCH fails THEN the system persists the assignee change, shows a generic "Save failed" toast, does not roll back the assignee, and does not re-fetch the step — leaving the UI out of sync with the actual persisted state
+
+1.2 WHEN a user edits both assignee and location in StepPropertiesEditor and the assignee PATCH fails THEN the system shows a generic "Save failed" toast without indicating which field failed, and the location PATCH is never attempted
+
+1.3 WHEN a user clears the location field in StepPropertiesEditor and saves THEN the system sends `{ location: '' }` to `PATCH /api/steps/:id/config`, which writes an empty string to the `location` column in SQLite instead of NULL, polluting the database with empty strings where NULLs are the convention
+
+1.4 WHEN the `onStepAssigned` function is defined in `app/pages/jobs/[id].vue` THEN it is unreachable dead code because the `@assigned` event binding was removed from StepTracker in the template during the step properties PR
+
+1.5 WHEN the `StepAssignmentDropdown.vue` component exists in `app/components/` THEN it is an orphaned file with no remaining template references, since StepTracker (its only consumer) was refactored to use inline text display for assignees
+
+### Expected Behavior (Correct)
+
+2.1 WHEN a user edits both assignee and location in StepPropertiesEditor and one PATCH request fails THEN the system SHALL re-fetch the step data so the UI reflects the actual persisted state, preventing the UI from showing stale or inconsistent values
+
+2.2 WHEN a user edits both assignee and location in StepPropertiesEditor and one PATCH request fails THEN the system SHALL display a toast message that indicates which specific field(s) failed to save
+
+2.3 WHEN a user clears the location field in StepPropertiesEditor and saves THEN the system SHALL normalize the empty or whitespace-only string to `undefined` (or `null`) in the API handler so that the database stores NULL instead of an empty string
+
+2.4 WHEN the `onStepAssigned` dead function is identified in `app/pages/jobs/[id].vue` THEN it SHALL be removed along with any related unused code
+
+2.5 WHEN the orphaned `StepAssignmentDropdown.vue` component is identified THEN the file SHALL be deleted from the codebase
+
+### Unchanged Behavior (Regression Prevention)
+
+3.1 WHEN both assignee and location PATCH requests succeed THEN the system SHALL CONTINUE TO show a "Step updated" success toast and emit the `saved` event
+
+3.2 WHEN neither assignee nor location has changed THEN the system SHALL CONTINUE TO emit the `saved` event immediately without making any API calls
+
+3.3 WHEN a user sets a non-empty location value THEN the system SHALL CONTINUE TO persist the location string as-is to the database
+
+3.4 WHEN the `PATCH /api/steps/:id/config` endpoint receives `optional` or `dependencyType` fields THEN the system SHALL CONTINUE TO process those fields correctly without any change in behavior
+
+3.5 WHEN the StepTracker component renders step data on the job detail page THEN the system SHALL CONTINUE TO display step distributions, assignee names, locations, and navigation correctly
+
+3.6 WHEN property-based tests reference `StepAssignmentDropdown` filter logic (e.g., `dropdownFilter.property.test.ts`) THEN those tests SHALL CONTINUE TO pass since they duplicate the filter logic inline and do not import the component file

--- a/.kiro/specs/step-properties-cleanup/design.md
+++ b/.kiro/specs/step-properties-cleanup/design.md
@@ -1,0 +1,154 @@
+# Design Document
+
+## Introduction
+
+GitHub Issue #109 — This design addresses one bug (partial save failure in `StepPropertiesEditor`) and three cleanup items (dead `onStepAssigned` function, orphaned `StepAssignmentDropdown.vue`, empty-string location values). All changes are scoped to four files plus one file deletion.
+
+## Affected Files
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `app/components/StepPropertiesEditor.vue` | Modify | Refactor `handleSave()` to attempt both requests independently, report per-field failures, and always re-fetch on error |
+| `server/api/steps/[id]/config.patch.ts` | Modify | Normalize empty/whitespace-only `location` to `undefined` before writing |
+| `app/pages/jobs/[id].vue` | Modify | Remove dead `onStepAssigned` function |
+| `app/components/StepAssignmentDropdown.vue` | Delete | Orphaned component with no remaining consumers |
+
+## Change Details
+
+### 1. Fix partial save in `StepPropertiesEditor.handleSave()` (Req 2.1, 2.2)
+
+Current `handleSave()` runs two sequential `$fetch` calls inside a single try/catch. If the first succeeds and the second throws, the catch shows a generic toast and the UI never re-fetches.
+
+The fix: attempt each changed field independently, collect per-field errors, then report results and always emit `saved` (which triggers the parent to re-fetch step data).
+
+```typescript
+async function handleSave() {
+  const newAssignee = selectedOrNull(selectedUserId.value as string)
+  const originalAssignee = props.currentAssignedTo ?? null
+  const assigneeChanged = newAssignee !== originalAssignee
+
+  const newLocation = selectedLocation.value
+  const originalLocation = props.currentLocation ?? ''
+  const locationChanged = newLocation !== originalLocation
+
+  if (!assigneeChanged && !locationChanged) {
+    emit('saved')
+    return
+  }
+
+  saving.value = true
+  const failures: string[] = []
+
+  if (assigneeChanged) {
+    try {
+      await $fetch(`/api/steps/${props.stepId}/assign`, {
+        method: 'PATCH',
+        body: { userId: newAssignee },
+      })
+    } catch {
+      failures.push('assignee')
+    }
+  }
+
+  if (locationChanged) {
+    try {
+      await $fetch(`/api/steps/${props.stepId}/config`, {
+        method: 'PATCH',
+        body: { location: newLocation },
+      })
+    } catch {
+      failures.push('location')
+    }
+  }
+
+  if (failures.length) {
+    toast.add({
+      title: 'Partial save failure',
+      description: `Failed to update: ${failures.join(', ')}. The page will refresh to show the current state.`,
+      color: 'error',
+    })
+  } else {
+    toast.add({
+      title: 'Step updated',
+      description: 'Step properties saved successfully.',
+      color: 'success',
+    })
+  }
+
+  saving.value = false
+  // Always emit saved so the parent re-fetches, ensuring UI reflects actual DB state
+  emit('saved')
+}
+```
+
+Key decisions:
+- Both requests are attempted independently — a failure in assignee does not block the location update.
+- The toast names the specific field(s) that failed.
+- `emit('saved')` always fires, which triggers the parent (`jobs/[id].vue`) to call `loadJob()` and re-fetch all step data. This ensures the UI reflects the actual persisted state even on partial failure.
+
+### 2. Normalize empty location in API handler (Req 2.3)
+
+In `server/api/steps/[id]/config.patch.ts`, add normalization after the `typeof` check:
+
+```typescript
+if (typeof body.location === 'string') {
+  const trimmed = body.location.trim()
+  update.location = trimmed === '' ? null : trimmed
+}
+```
+
+This converts empty or whitespace-only strings to `null` so the DB stores NULL instead of `''`. Non-empty strings pass through unchanged (Req 3.3). The `optional` and `dependencyType` fields are untouched (Req 3.4).
+
+### 3. Remove dead `onStepAssigned` function (Req 2.4)
+
+Delete the entire `onStepAssigned` function from `app/pages/jobs/[id].vue` (lines ~114-121). No template binding references it — the `@assigned` event was removed from `StepTracker` in the step properties PR. The function body (`loadAllDistributions` + re-fetch paths) is already handled by `onStepConfigUpdated` and `loadJob`.
+
+### 4. Delete orphaned `StepAssignmentDropdown.vue` (Req 2.5)
+
+Delete `app/components/StepAssignmentDropdown.vue`. Confirmed no template references remain in the codebase. The property tests (`dropdownFilter.property.test.ts`, `stepAssignmentBugCondition.property.test.ts`, `stepAssignmentPreservation.property.test.ts`) duplicate the filter logic inline and do not import the component file, so they are unaffected (Req 3.6).
+
+## Sequence Diagram — Fixed `handleSave()` Flow
+
+```
+User clicks Save
+       │
+       ▼
+  assigneeChanged? ──yes──▶ PATCH /api/steps/:id/assign
+       │                         │
+       │                    success/fail → record result
+       │                         │
+       ▼                         ▼
+  locationChanged? ──yes──▶ PATCH /api/steps/:id/config
+       │                         │
+       │                    success/fail → record result
+       │                         │
+       ▼                         ▼
+  Any failures? ──yes──▶ Toast: "Failed to update: [fields]"
+       │
+       no──▶ Toast: "Step updated"
+       │
+       ▼
+  emit('saved')  ──▶  Parent re-fetches step data
+```
+
+## Tasks
+
+- [ ] 1. Refactor `handleSave()` in `app/components/StepPropertiesEditor.vue`
+  - Replace single try/catch with independent per-field try/catch blocks
+  - Collect failures into an array and report specific field names in the toast
+  - Always emit `saved` at the end so the parent re-fetches
+  - _Requirements: 2.1, 2.2, 3.1, 3.2_
+
+- [ ] 2. Normalize empty location in `server/api/steps/[id]/config.patch.ts`
+  - After the `typeof body.location === 'string'` check, trim the value
+  - If trimmed string is empty, set `update.location = null` instead of the empty string
+  - _Requirements: 2.3, 3.3, 3.4_
+
+- [ ] 3. Remove dead `onStepAssigned` function from `app/pages/jobs/[id].vue`
+  - Delete the `onStepAssigned` function definition (approx lines 114-121)
+  - _Requirements: 2.4_
+
+- [ ] 4. Delete orphaned `app/components/StepAssignmentDropdown.vue`
+  - Remove the file entirely
+  - Verify property tests still pass (they duplicate logic inline, no component import)
+  - _Requirements: 2.5, 3.6_


### PR DESCRIPTION
Fixes #109

## Summary

Bugfix spec and design for cleaning up issues found in code review of the step properties PR (#108) and add-note-to-parts PR (#107).

## What's included so far

- Bugfix requirements document (`bugfix.md`) covering all four items from the issue
- Design document (`design.md`) with implementation plan

## Planned changes (per design)

1. **Fix partial save in StepPropertiesEditor** — independent try/catch per field, report which field(s) failed, always re-fetch on error
2. **Normalize empty location to NULL** — trim + nullify empty strings in `config.patch.ts`
3. **Remove dead `onStepAssigned` function** — unreachable code in `jobs/[id].vue`
4. **Delete orphaned `StepAssignmentDropdown.vue`** — no remaining consumers