### PR TITLE
feat: add Zod schema validation for path/step API routes

### DIFF
--- a/.kiro/steering/coding-standards.md
+++ b/.kiro/steering/coding-standards.md
@@ -86,6 +86,32 @@ if (!id) throw new ValidationError('ID is required')
 if (!id) throw createError({ statusCode: 400, message: 'ID is required' })
 ```
 
+## Request Body Validation (Zod Schemas)
+
+API routes that accept request bodies should validate them with Zod schemas using `parseBody()` (auto-imported from `server/utils/validation.ts`). This ensures invalid input returns a 400 instead of a 500.
+
+Schemas live in `server/schemas/` and are colocated by domain (e.g., `pathSchemas.ts`, `jobSchemas.ts`). Each route imports its schema and calls `parseBody(event, schema)` instead of raw `readBody(event)`.
+
+```ts
+// CORRECT — validated input, wrong types → 400
+import { createPathSchema } from '../../schemas/pathSchemas'
+
+export default defineApiHandler(async (event) => {
+  const body = await parseBody(event, createPathSchema)
+  return getServices().pathService.createPath(body)
+})
+```
+
+```ts
+// WRONG — unvalidated input, wrong types → 500
+export default defineApiHandler(async (event) => {
+  const body = await readBody(event)
+  return getServices().pathService.createPath(body)
+})
+```
+
+When adding a new route with a request body, define a Zod schema in the appropriate `server/schemas/*.ts` file and use `parseBody`. Existing routes are being migrated incrementally — when touching an existing route, convert it to use `parseBody` if it doesn't already.
+
 ## API Error Handling — Empty vs. Not Found
 
 A 404 means the resource itself doesn't exist — not that it has zero children. Empty lists are valid 200 responses.

--- a/AI-MAP.md
+++ b/AI-MAP.md
@@ -20,6 +20,7 @@ Shop Planr (package name: `shop-erp`) is a job routing and ERP application for m
 | Icons | `@iconify-json/lucide` |
 | Database | SQLite via `better-sqlite3` |
 | ID Generation | `nanoid` |
+| Validation | `zod` (API request body schemas) |
 | Testing | Vitest 3.2 + `happy-dom` + `fast-check` (PBT) + `tsx` (seed scripts) |
 | Linting | ESLint 9 via `@nuxt/eslint` |
 | Deployment | Docker (single container, copies `.output/`) |
@@ -57,11 +58,12 @@ server/
     httpError.ts         → STATUS_MESSAGES, ERROR_STATUS_MAP, httpError(), defineApiHandler() — centralized HTTP error handler replacing per-route try/catch blocks
     idGenerator.ts       → generateId(prefix), createSequentialSnGenerator()
     serialization.ts     → serialize(), deserialize(), prettyPrint() for all domain types
-    validation.ts        → assertPositive, assertNonEmpty, assertNonEmptyArray, assertOneOf, etc.
+    validation.ts        → assertPositive, assertNonEmpty, assertNonEmptyArray, assertOneOf, parseBody() (Zod schema validation)
     db.ts                → getRepositories() singleton — lazy-inits from runtimeConfig
     workQueueGrouping.ts → groupEntriesByDimension() — pure server-side grouping by user/location/step dimension
     services.ts          → getServices() singleton — wires all 12 services together
     pageToggles.ts       → DEFAULT_PAGE_TOGGLES, ROUTE_TOGGLE_MAP, ALWAYS_ENABLED_ROUTES, mergePageToggles(), isPageEnabled() — auto-imported by Nitro
+  schemas/               → Zod request body schemas by domain (pathSchemas.ts, etc.)
   types/
     domain.ts            → 26+ domain types (Job, Path, ProcessStep, SerialNumber, SnStepStatus, SnStepOverride, BomVersion, ProcessLibraryEntry, LocationLibraryEntry, etc.)
     api.ts               → 25+ API input types (ScrapSerialInput, ForceCompleteInput, AdvanceToStepInput, EditBomInput, etc.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@nuxt/ui": "^4.3.0",
         "better-sqlite3": "^12.8.0",
         "nanoid": "^5.1.6",
-        "nuxt": "^4.2.2"
+        "nuxt": "^4.2.2",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@nuxt/eslint": "^1.12.1",
@@ -1802,11 +1803,33 @@
         }
       }
     },
+    "node_modules/@nuxt/cli/node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nuxt/cli/node_modules/citty": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
       "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
       "license": "MIT"
+    },
+    "node_modules/@nuxt/cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@nuxt/cli/node_modules/giget": {
       "version": "3.2.0",
@@ -1901,6 +1924,15 @@
         "valibot": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nuxt/content/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@nuxt/devalue": {
@@ -8393,6 +8425,16 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/ci-info": {
@@ -20639,9 +20681,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@nuxt/ui": "^4.3.0",
     "better-sqlite3": "^12.8.0",
     "nanoid": "^5.1.6",
-    "nuxt": "^4.2.2"
+    "nuxt": "^4.2.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.12.1",

--- a/server/api/paths/[id].delete.ts
+++ b/server/api/paths/[id].delete.ts
@@ -1,7 +1,8 @@
+import { deletePathSchema } from '../../schemas/pathSchemas'
+
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
-  if (!body?.userId) throw new ValidationError('userId is required')
+  const body = await parseBody(event, deletePathSchema)
   const { pathService } = getServices()
   const result = pathService.deletePath(id, body.userId)
   return { success: true, ...result }

--- a/server/api/paths/[id].put.ts
+++ b/server/api/paths/[id].put.ts
@@ -1,6 +1,8 @@
+import { updatePathSchema } from '../../schemas/pathSchemas'
+
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, updatePathSchema)
   const { pathService } = getServices()
   return pathService.updatePath(id, body)
 })

--- a/server/api/paths/[id]/advancement-mode.patch.ts
+++ b/server/api/paths/[id]/advancement-mode.patch.ts
@@ -1,6 +1,8 @@
+import { updateAdvancementModeSchema } from '../../../schemas/pathSchemas'
+
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, updateAdvancementModeSchema)
   const { pathService } = getServices()
   return pathService.updatePath(id, { advancementMode: body.advancementMode })
 })

--- a/server/api/paths/index.post.ts
+++ b/server/api/paths/index.post.ts
@@ -1,5 +1,7 @@
+import { createPathSchema } from '../../schemas/pathSchemas'
+
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, createPathSchema)
   const { pathService } = getServices()
   return pathService.createPath(body)
 })

--- a/server/api/steps/[id]/assign.patch.ts
+++ b/server/api/steps/[id]/assign.patch.ts
@@ -1,6 +1,8 @@
+import { assignStepSchema } from '../../../schemas/pathSchemas'
+
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, assignStepSchema)
   const { pathService } = getServices()
   return pathService.assignStep(id, body.userId)
 })

--- a/server/api/steps/[id]/config.patch.ts
+++ b/server/api/steps/[id]/config.patch.ts
@@ -1,21 +1,19 @@
+import { updateStepConfigSchema } from '../../../schemas/pathSchemas'
+
 export default defineApiHandler(async (event) => {
   const stepId = getRouterParam(event, 'id')
   if (!stepId) throw new ValidationError('Step ID is required')
 
-  const body = await readBody(event)
+  const body = await parseBody(event, updateStepConfigSchema)
   const { pathService } = getServices()
 
   const update: Record<string, unknown> = {}
   if (typeof body.optional === 'boolean') update.optional = body.optional
-  if (typeof body.location === 'string') update.location = body.location
-  if (body.dependencyType && ['physical', 'preferred', 'completion_gate'].includes(body.dependencyType)) {
-    update.dependencyType = body.dependencyType
+  if (typeof body.location === 'string') {
+    const trimmed = body.location.trim()
+    update.location = trimmed || undefined
   }
+  if (body.dependencyType) update.dependencyType = body.dependencyType
 
-  if (!Object.keys(update).length) {
-    throw new ValidationError('No valid fields to update')
-  }
-
-  const result = pathService.updateStep(stepId, update)
-  return result
+  return pathService.updateStep(stepId, update)
 })

--- a/server/schemas/pathSchemas.ts
+++ b/server/schemas/pathSchemas.ts
@@ -1,0 +1,57 @@
+/**
+ * Zod schemas for path and step API endpoints.
+ *
+ * These schemas validate request bodies at the API boundary,
+ * ensuring services receive correctly-typed inputs.
+ */
+import { z } from 'zod'
+
+const dependencyTypeEnum = z.enum(['physical', 'preferred', 'completion_gate'])
+const advancementModeEnum = z.enum(['strict', 'flexible', 'per_step'])
+
+// ── Step schemas ──
+
+const stepInputSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1, 'Step name is required'),
+  location: z.string().optional(),
+  assignedTo: z.string().nullable().optional(),
+  optional: z.boolean().optional(),
+  dependencyType: dependencyTypeEnum.optional(),
+})
+
+export const createPathSchema = z.object({
+  jobId: z.string().min(1, 'jobId is required'),
+  name: z.string().min(1, 'name is required'),
+  goalQuantity: z.number().int().positive('goalQuantity must be a positive integer'),
+  advancementMode: advancementModeEnum.optional(),
+  steps: z.array(stepInputSchema).min(1, 'At least one step is required'),
+})
+
+export const updatePathSchema = z.object({
+  name: z.string().min(1).optional(),
+  goalQuantity: z.number().int().positive().optional(),
+  advancementMode: advancementModeEnum.optional(),
+  steps: z.array(stepInputSchema).min(1).optional(),
+})
+
+export const deletePathSchema = z.object({
+  userId: z.string().min(1, 'userId is required'),
+})
+
+export const updateAdvancementModeSchema = z.object({
+  advancementMode: advancementModeEnum,
+})
+
+export const assignStepSchema = z.object({
+  userId: z.string().nullable(),
+})
+
+export const updateStepConfigSchema = z.object({
+  optional: z.boolean().optional(),
+  location: z.string().optional(),
+  dependencyType: dependencyTypeEnum.optional(),
+}).refine(
+  data => Object.values(data).some(v => v !== undefined),
+  { message: 'No valid fields to update' },
+)

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -46,3 +46,44 @@ export function assertDefined<T>(value: T | null | undefined, fieldName: string)
     throw new ValidationError(`${fieldName} is required`)
   }
 }
+
+// ── Zod-based request body parsing ──
+
+import type { H3Event } from 'h3'
+import type { ZodType, ZodError } from 'zod'
+
+/**
+ * Reads and validates the request body against a Zod schema.
+ * Throws `ValidationError` (caught by `defineApiHandler` → 400) on failure.
+ *
+ * Usage:
+ * ```ts
+ * import { z } from 'zod'
+ * const Schema = z.object({ name: z.string().min(1) })
+ *
+ * export default defineApiHandler(async (event) => {
+ *   const body = await parseBody(event, Schema)
+ * })
+ * ```
+ */
+export async function parseBody<T>(event: H3Event, schema: ZodType<T>): Promise<T> {
+  const raw = await readBody(event)
+  const result = schema.safeParse(raw)
+  if (!result.success) {
+    throw new ValidationError(formatZodError(result.error))
+  }
+  return result.data
+}
+
+/**
+ * Formats a ZodError into a concise, human-readable message.
+ * Example: "name: Required; steps.0.name: Expected string, received number"
+ */
+function formatZodError(error: ZodError): string {
+  return error.issues
+    .map(issue => {
+      const path = issue.path.length ? issue.path.join('.') + ': ' : ''
+      return path + issue.message
+    })
+    .join('; ')
+}

--- a/tests/unit/components/StepPropertiesEditor.test.ts
+++ b/tests/unit/components/StepPropertiesEditor.test.ts
@@ -354,4 +354,99 @@ describe('StepPropertiesEditor', () => {
       expect(wrapper.emitted('saved')).toHaveLength(1)
     })
   })
+
+  // ── PATCH failure scenarios ──
+  describe('PATCH failure handling', () => {
+    it('shows error toast when assignee PATCH fails and still emits saved', async () => {
+      mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/assign')) return Promise.reject(new Error('Network error'))
+        return Promise.resolve({})
+      })
+
+      const wrapper = mountEditor({
+        stepId: 'step-1',
+        currentAssignedTo: 'user-1',
+        currentLocation: 'Bay 1',
+      })
+
+      await wrapper.find('[data-testid="assignee-select"]').setValue('user-2')
+      await wrapper.find('[data-testid="location-input"]').setValue('Bay 3')
+      await wrapper.find('[data-testid="save-btn"]').trigger('click')
+      await flushPromises()
+
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        title: 'Partial save',
+        description: 'Failed to update assignee. Other changes were saved.',
+        color: 'error',
+      })
+      expect(wrapper.emitted('saved')).toHaveLength(1)
+    })
+
+    it('shows error toast when location PATCH fails and still emits saved', async () => {
+      mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/config')) return Promise.reject(new Error('Network error'))
+        return Promise.resolve({})
+      })
+
+      const wrapper = mountEditor({
+        stepId: 'step-1',
+        currentAssignedTo: 'user-1',
+        currentLocation: 'Bay 1',
+      })
+
+      await wrapper.find('[data-testid="assignee-select"]').setValue('user-2')
+      await wrapper.find('[data-testid="location-input"]').setValue('Bay 3')
+      await wrapper.find('[data-testid="save-btn"]').trigger('click')
+      await flushPromises()
+
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        title: 'Partial save',
+        description: 'Failed to update location. Other changes were saved.',
+        color: 'error',
+      })
+      expect(wrapper.emitted('saved')).toHaveLength(1)
+    })
+
+    it('shows combined error toast when both PATCHes fail and still emits saved', async () => {
+      mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
+
+      const wrapper = mountEditor({
+        stepId: 'step-1',
+        currentAssignedTo: 'user-1',
+        currentLocation: 'Bay 1',
+      })
+
+      await wrapper.find('[data-testid="assignee-select"]').setValue('user-2')
+      await wrapper.find('[data-testid="location-input"]').setValue('Bay 3')
+      await wrapper.find('[data-testid="save-btn"]').trigger('click')
+      await flushPromises()
+
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        title: 'Partial save',
+        description: 'Failed to update assignee and location. Other changes were saved.',
+        color: 'error',
+      })
+      expect(wrapper.emitted('saved')).toHaveLength(1)
+    })
+
+    it('shows success toast when all PATCHes succeed', async () => {
+      const wrapper = mountEditor({
+        stepId: 'step-1',
+        currentAssignedTo: 'user-1',
+        currentLocation: 'Bay 1',
+      })
+
+      await wrapper.find('[data-testid="assignee-select"]').setValue('user-2')
+      await wrapper.find('[data-testid="location-input"]').setValue('Bay 3')
+      await wrapper.find('[data-testid="save-btn"]').trigger('click')
+      await flushPromises()
+
+      expect(mockToastAdd).toHaveBeenCalledWith({
+        title: 'Step updated',
+        description: 'Step properties saved successfully.',
+        color: 'success',
+      })
+      expect(wrapper.emitted('saved')).toHaveLength(1)
+    })
+  })
 })


### PR DESCRIPTION
- Install zod for runtime request body validation
- Add parseBody() helper to server/utils/validation.ts
- Create server/schemas/pathSchemas.ts with schemas for all 6 path/step routes
- Convert path CRUD + step assign/config routes to use parseBody
- Invalid input now returns 400 instead of 500
- Add PATCH failure scenario tests for StepPropertiesEditor
- Update coding standards and AI-MAP with validation pattern