### PR TITLE
Fix smoke test endpoint

### DIFF
--- a/.github/workflows/deploy-only.yml
+++ b/.github/workflows/deploy-only.yml
@@ -39,7 +39,7 @@ jobs:
           curl -sf http://localhost:3000 > /dev/null
           echo "✅ Frontend OK"
           echo "Checking API..."
-          curl -sf http://localhost:3000/api/jobs > /dev/null
+          curl -sf http://localhost:3000/api/health > /dev/null
           echo "✅ API OK"
           kill $SERVER_PID
 
@@ -87,7 +87,7 @@ jobs:
               echo "❌ Frontend health check failed"
               FAILED=1
             fi
-            if curl -sf http://localhost:3005/api/jobs > /dev/null; then
+            if curl -sf http://localhost:3005/api/health > /dev/null; then
               echo "✅ API health check passed"
             else
               echo "❌ API health check failed"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
           curl -sf http://localhost:3000 > /dev/null
           echo "✅ Frontend OK"
           echo "Checking API..."
-          curl -sf http://localhost:3000/api/jobs > /dev/null
+          curl -sf http://localhost:3000/api/health > /dev/null
           echo "✅ API OK"
           kill $SERVER_PID
 
@@ -100,7 +100,7 @@ jobs:
               echo "❌ Frontend health check failed"
               FAILED=1
             fi
-            if curl -sf http://localhost:3005/api/jobs > /dev/null; then
+            if curl -sf http://localhost:3005/api/health > /dev/null; then
               echo "✅ API health check passed"
             else
               echo "❌ API health check failed"

--- a/server/api/health.get.ts
+++ b/server/api/health.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => ({ status: 'ok' }))

--- a/server/middleware/02.auth.ts
+++ b/server/middleware/02.auth.ts
@@ -1,4 +1,5 @@
 const EXEMPT_ROUTES: Array<{ method: string, path: string }> = [
+  { method: 'GET', path: '/api/health' },
   { method: 'POST', path: '/api/auth/login' },
   { method: 'POST', path: '/api/auth/setup-pin' },
   { method: 'GET', path: '/api/users' },


### PR DESCRIPTION
Auth middleware killed the health check endpoint. This fixes it so our smoke check doesn't get rejected.