### PR TITLE
fix: replace N+1 job progress requests with single bulk endpoint

### DIFF
--- a/app/pages/jobs/index.vue
+++ b/app/pages/jobs/index.vue
@@ -106,19 +106,20 @@ async function loadJobs() {
 }
 
 async function loadAllProgress() {
-  const results = await Promise.allSettled(
-    jobs.value.map(job =>
-      $api<{ progress: JobProgress }>(`/api/jobs/${job.id}`)
-        .then(detail => ({ id: job.id, progress: detail.progress })),
-    ),
-  )
-  const map: Record<string, JobProgress> = {}
-  for (const r of results) {
-    if (r.status === 'fulfilled') {
-      map[r.value.id] = r.value.progress
+  try {
+    const progressList = await $api<JobProgress[]>('/api/jobs/progress')
+    const map: Record<string, JobProgress> = {}
+    for (const p of progressList) {
+      map[p.jobId] = p
     }
+    jobProgressMap.value = map
+  } catch {
+    toast.add({
+      title: 'Could not load progress data',
+      description: 'Job list is still available. Progress bars may be missing or stale.',
+      color: 'warning',
+    })
   }
-  jobProgressMap.value = map
 }
 
 function progressFor(jobId: string): JobProgress | null {


### PR DESCRIPTION
The jobs page was firing one GET /api/jobs/{id} per job to fetch progress, causing 429 rate limit errors when job count exceeded 60. Replaced with a single call to GET /api/jobs/progress which computes all progress in one query via countsByJob().

fixes additional rate limit issue