### PR TITLE
Chore/step view UI tweaks

### DIFF
--- a/app/components/PartCreationPanel.vue
+++ b/app/components/PartCreationPanel.vue
@@ -13,6 +13,7 @@ const emit = defineEmits<{
 }>()
 
 const { batchCreateParts } = useParts()
+const { users } = useAuth()
 
 const quantity = ref<number>(1)
 const creating = ref(false)
@@ -37,9 +38,13 @@ function validateQuantity() {
 function formatDestination(): string {
   if (props.job.isFinalStep) return 'Completed'
   if (!props.job.nextStepName) return '—'
-  return props.job.nextStepLocation
-    ? `${props.job.nextStepName} → ${props.job.nextStepLocation}`
-    : props.job.nextStepName
+  let dest = props.job.nextStepName
+  if (props.job.nextStepLocation) dest += ` → ${props.job.nextStepLocation}`
+  if (props.job.nextStepAssignedTo) {
+    const user = users.value.find(u => u.id === props.job.nextStepAssignedTo)
+    if (user) dest += ` · ${user.displayName}`
+  }
+  return dest
 }
 
 function togglePart(partId: string) {

--- a/app/components/ProcessAdvancementPanel.vue
+++ b/app/components/ProcessAdvancementPanel.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{
   noteAdded: [note: StepNote]
 }>()
 
-const { isAdmin } = useAuth()
+const { isAdmin, users } = useAuth()
 const { advanceToStep } = useLifecycle()
 const toast = useToast()
 
@@ -154,9 +154,13 @@ function handleAdvance() {
 function formatDestination(): string {
   if (props.job.isFinalStep) return 'Completed'
   if (!props.job.nextStepName) return '—'
-  return props.job.nextStepLocation
-    ? `${props.job.nextStepName} → ${props.job.nextStepLocation}`
-    : props.job.nextStepName
+  let dest = props.job.nextStepName
+  if (props.job.nextStepLocation) dest += ` → ${props.job.nextStepLocation}`
+  if (props.job.nextStepAssignedTo) {
+    const user = users.value.find(u => u.id === props.job.nextStepAssignedTo)
+    if (user) dest += ` · ${user.displayName}`
+  }
+  return dest
 }
 
 function openScrap(partId: string) {

--- a/app/components/StepTracker.vue
+++ b/app/components/StepTracker.vue
@@ -56,7 +56,14 @@ function computeColumns() {
   // For N cards: N * CARD_MIN_WIDTH + (N-1) * (ARROW_WIDTH + GAP) + (N-1) * GAP <= width
   // Simplify: each card slot = CARD_MIN_WIDTH, each gap between = ARROW_WIDTH + 2*GAP
   const slotGap = ARROW_WIDTH + 2 * GAP
-  const cols = Math.max(2, Math.floor((width + slotGap) / (CARD_MIN_WIDTH + slotGap)))
+  const maxCols = allItems.value.length || 1
+  let cols = Math.min(maxCols, Math.max(1, Math.floor((width + slotGap) / (CARD_MIN_WIDTH + slotGap))))
+  // Reduce columns if cardWidth would fall below CARD_MIN_WIDTH
+  while (cols > 1) {
+    const arrowSpace = (cols - 1) * (ARROW_WIDTH + 2 * GAP)
+    if (Math.floor((width - arrowSpace) / cols) >= CARD_MIN_WIDTH) break
+    cols--
+  }
   columnsPerRow.value = cols
 }
 

--- a/app/components/StepTracker.vue
+++ b/app/components/StepTracker.vue
@@ -40,32 +40,93 @@ function depIcon(depType?: string) {
     default: return ''
   }
 }
+
+// Grid layout: compute how many cards fit per row based on container width
+const containerRef = ref<HTMLElement | null>(null)
+const columnsPerRow = ref(8)
+const containerWidth = ref(0)
+const CARD_MIN_WIDTH = 120
+const ARROW_WIDTH = 20
+const GAP = 4 // gap-x-1 = 0.25rem = 4px
+
+function computeColumns() {
+  const el = containerRef.value
+  if (!el) return
+  const width = el.clientWidth
+  containerWidth.value = width
+  // For N cards: N * CARD_MIN_WIDTH + (N-1) * (ARROW_WIDTH + GAP) + (N-1) * GAP <= width
+  // Simplify: each card slot = CARD_MIN_WIDTH, each gap between = ARROW_WIDTH + 2*GAP
+  const slotGap = ARROW_WIDTH + 2 * GAP
+  const cols = Math.max(2, Math.floor((width + slotGap) / (CARD_MIN_WIDTH + slotGap)))
+  columnsPerRow.value = cols
+}
+
+// Fixed card width so all cards across all rows are the same size
+const cardWidth = computed(() => {
+  if (!containerWidth.value || !columnsPerRow.value) return CARD_MIN_WIDTH
+  const n = columnsPerRow.value
+  // Total arrow+gap space between n cards: (n-1) arrows, each with gap on both sides
+  const arrowSpace = (n - 1) * (ARROW_WIDTH + 2 * GAP)
+  return Math.floor((containerWidth.value - arrowSpace) / n)
+})
+
+// All items: steps + done sentinel
+interface RowItem {
+  type: 'step' | 'done'
+  step?: StepDistribution
+  index: number // original index in distribution (for step label "Step N")
+}
+
+const allItems = computed<RowItem[]>(() => {
+  const items: RowItem[] = props.distribution.map((s, i) => ({ type: 'step', step: s, index: i }))
+  items.push({ type: 'done', index: props.distribution.length })
+  return items
+})
+
+const rows = computed<RowItem[][]>(() => {
+  const result: RowItem[][] = []
+  const items = allItems.value
+  for (let i = 0; i < items.length; i += columnsPerRow.value) {
+    result.push(items.slice(i, i + columnsPerRow.value))
+  }
+  return result
+})
+
+let resizeObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  nextTick(computeColumns)
+  if (containerRef.value) {
+    resizeObserver = new ResizeObserver(computeColumns)
+    resizeObserver.observe(containerRef.value)
+  }
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+})
+
+watch(() => props.distribution, () => nextTick(computeColumns))
 </script>
 
 <template>
-  <div class="flex flex-col md:flex-row md:flex-wrap justify-start gap-x-1 gap-y-2 items-stretch py-1">
+  <!-- Mobile layout: vertical stack -->
+  <div class="md:hidden flex flex-col gap-y-2 py-1">
     <template
       v-for="(step, i) in distribution"
       :key="step.stepId"
     >
-      <!-- Arrow between steps -->
       <div
         v-if="i > 0"
-        class="flex items-center justify-center shrink-0"
+        class="flex items-center justify-center"
       >
         <UIcon
-          name="i-lucide-chevron-right"
-          class="size-4 text-(--ui-text-muted) hidden md:block"
-        />
-        <UIcon
           name="i-lucide-chevron-down"
-          class="size-4 text-(--ui-text-muted) md:hidden"
+          class="size-4 text-(--ui-text-muted)"
         />
       </div>
-
-      <!-- Mobile: horizontal card layout -->
       <div
-        class="md:hidden rounded border px-3 py-2 cursor-pointer transition-colors hover:border-(--ui-primary) hover:bg-(--ui-primary)/5"
+        class="rounded border px-3 py-2 cursor-pointer transition-colors hover:border-(--ui-primary) hover:bg-(--ui-primary)/5"
         :class="stepBorderClass(step)"
         role="button"
         tabindex="0"
@@ -119,73 +180,18 @@ function depIcon(depType?: string) {
           👤 {{ getProcessStep(step.stepId)?.assignedTo ? users.find(u => u.id === getProcessStep(step.stepId)?.assignedTo)?.displayName ?? 'Assigned' : 'Unassigned' }}
         </div>
       </div>
-
-      <!-- Desktop: compact centered card -->
-      <div
-        class="hidden md:flex flex-col items-center justify-center md:min-w-[110px] md:max-w-[150px] md:flex-1 px-1.5 py-1 rounded border text-center cursor-pointer transition-colors hover:border-(--ui-primary) hover:bg-(--ui-primary)/5"
-        :class="stepBorderClass(step)"
-        @click="handleStepClick(step)"
-      >
-        <span class="text-[10px] text-(--ui-text-muted) mb-0.5 flex items-center gap-0.5">
-          Step {{ i + 1 }}
-          <UIcon
-            v-if="depIcon(getProcessStep(step.stepId)?.dependencyType)"
-            :name="depIcon(getProcessStep(step.stepId)?.dependencyType)!"
-            class="size-2.5"
-          />
-        </span>
-        <span
-          class="text-xs font-medium text-(--ui-text-highlighted) truncate max-w-[100px]"
-          :title="step.stepName"
-        >{{ step.stepName }}</span>
-        <span
-          v-if="step.location"
-          class="text-[10px] text-(--ui-text-muted) truncate max-w-[100px]"
-          :title="step.location"
-        >{{ step.location }}</span>
-        <!-- Optional label -->
-        <span
-          v-if="getProcessStep(step.stepId)?.optional"
-          class="text-[9px] text-(--ui-text-muted) italic"
-        >Optional</span>
-        <div class="mt-1 flex items-center gap-1 text-[10px]">
-          <span class="font-bold text-(--ui-text-highlighted)">{{ step.partCount }}</span>
-          <span class="text-(--ui-text-muted)">at ·</span>
-          <span class="text-green-600 dark:text-green-400">{{ step.completedCount }} done</span>
-        </div>
-        <BottleneckBadge
-          v-if="step.isBottleneck"
-          :is-bottleneck="true"
-          class="mt-1"
-        />
-        <!-- Step assignee display -->
-        <span
-          v-if="users.length"
-          class="mt-1 text-[10px] text-(--ui-text-muted) truncate max-w-[100px]"
-          :title="getProcessStep(step.stepId)?.assignedTo ? users.find(u => u.id === getProcessStep(step.stepId)?.assignedTo)?.displayName ?? 'Assigned' : 'Unassigned'"
-        >
-          👤 {{ getProcessStep(step.stepId)?.assignedTo ? users.find(u => u.id === getProcessStep(step.stepId)?.assignedTo)?.displayName ?? 'Assigned' : 'Unassigned' }}
-        </span>
-      </div>
     </template>
-
-    <!-- Arrow before Done -->
+    <!-- Mobile Done -->
     <div
       v-if="distribution.length"
-      class="flex items-center justify-center shrink-0"
+      class="flex items-center justify-center"
     >
       <UIcon
-        name="i-lucide-chevron-right"
-        class="size-4 text-(--ui-text-muted) hidden md:block"
-      />
-      <UIcon
         name="i-lucide-chevron-down"
-        class="size-4 text-(--ui-text-muted) md:hidden"
+        class="size-4 text-(--ui-text-muted)"
       />
     </div>
-
-    <!-- Completed column — mobile -->
-    <div class="md:hidden flex items-center justify-between rounded border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-950/30 px-3 py-2">
+    <div class="flex items-center justify-between rounded border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-950/30 px-3 py-2">
       <div class="flex items-center gap-2">
         <UIcon
           name="i-lucide-check-circle"
@@ -195,20 +201,107 @@ function depIcon(depType?: string) {
       </div>
       <span class="text-sm font-bold text-green-600 dark:text-green-400">{{ completedCount }} completed</span>
     </div>
+  </div>
 
-    <!-- Completed column — desktop -->
-    <div class="hidden md:flex flex-col items-center justify-center md:min-w-[110px] md:max-w-[150px] md:flex-1 px-1.5 py-1 rounded border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-950/30 text-center">
-      <span class="text-[10px] text-(--ui-text-muted) mb-0.5">Done</span>
-      <UIcon
-        name="i-lucide-check-circle"
-        class="size-4 text-green-600 dark:text-green-400"
-      />
-      <div class="mt-1">
-        <span class="text-sm font-bold text-green-600 dark:text-green-400">
-          {{ completedCount }}
-        </span>
+  <!-- Desktop layout: grid rows -->
+  <div
+    ref="containerRef"
+    class="hidden md:flex flex-col gap-y-3 py-1"
+  >
+    <template
+      v-for="(row, rowIdx) in rows"
+      :key="rowIdx"
+    >
+      <hr
+        v-if="rowIdx > 0"
+        class="border-(--ui-border)/50"
+      >
+      <div
+        class="flex items-stretch gap-x-1"
+        :class="row.length < columnsPerRow ? 'justify-center' : ''"
+      >
+      <template
+        v-for="(item, colIdx) in row"
+        :key="item.type === 'step' ? item.step!.stepId : 'done'"
+      >
+        <!-- Arrow between cards (not before first in row) -->
+        <div
+          v-if="colIdx > 0"
+          class="flex items-center justify-center shrink-0"
+        >
+          <UIcon
+            name="i-lucide-chevron-right"
+            class="size-4 text-(--ui-text-muted)"
+          />
+        </div>
+
+        <!-- Step card -->
+        <div
+          v-if="item.type === 'step'"
+          class="flex flex-col items-center justify-center shrink-0 px-2 py-2.5 rounded border text-center cursor-pointer transition-colors hover:border-(--ui-primary) hover:bg-(--ui-primary)/5"
+          :class="stepBorderClass(item.step!)"
+          :style="{ width: `${cardWidth}px` }"
+          @click="handleStepClick(item.step!)"
+        >
+          <span class="text-[10px] text-(--ui-text-muted) mb-0.5 flex items-center gap-0.5">
+            Step {{ item.index + 1 }}
+            <UIcon
+              v-if="depIcon(getProcessStep(item.step!.stepId)?.dependencyType)"
+              :name="depIcon(getProcessStep(item.step!.stepId)?.dependencyType)!"
+              class="size-2.5"
+            />
+            <BottleneckBadge
+              v-if="item.step!.isBottleneck"
+              :is-bottleneck="true"
+            />
+          </span>
+          <span
+            class="text-xs font-medium text-(--ui-text-highlighted) text-center break-words"
+            :title="item.step!.stepName"
+          >{{ item.step!.stepName }}</span>
+          <span
+            v-if="item.step!.location"
+            class="text-[10px] text-(--ui-text-muted) text-center break-words"
+            :title="item.step!.location"
+          >{{ item.step!.location }}</span>
+          <span
+            v-if="getProcessStep(item.step!.stepId)?.optional"
+            class="text-[9px] text-(--ui-text-muted) italic"
+          >Optional</span>
+          <div class="mt-1 flex items-center gap-1 text-[10px] flex-wrap justify-center">
+            <span class="font-bold text-(--ui-text-highlighted)">{{ item.step!.partCount }}</span>
+            <span class="text-(--ui-text-muted)">at ·</span>
+            <span class="text-green-600 dark:text-green-400">{{ item.step!.completedCount }} done</span>
+          </div>
+          <span
+            v-if="users.length"
+            class="mt-1 text-[10px] text-(--ui-text-muted) text-center break-words"
+            :title="getProcessStep(item.step!.stepId)?.assignedTo ? users.find(u => u.id === getProcessStep(item.step!.stepId)?.assignedTo)?.displayName ?? 'Assigned' : 'Unassigned'"
+          >
+            👤 {{ getProcessStep(item.step!.stepId)?.assignedTo ? users.find(u => u.id === getProcessStep(item.step!.stepId)?.assignedTo)?.displayName ?? 'Assigned' : 'Unassigned' }}
+          </span>
+        </div>
+
+        <!-- Done card -->
+        <div
+          v-else
+          class="flex flex-col items-center justify-center shrink-0 px-2 py-1.5 rounded border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-950/30 text-center"
+          :style="{ width: `${cardWidth}px` }"
+        >
+          <span class="text-[10px] text-(--ui-text-muted) mb-0.5">Done</span>
+          <UIcon
+            name="i-lucide-check-circle"
+            class="size-4 text-green-600 dark:text-green-400"
+          />
+          <div class="mt-1">
+            <span class="text-sm font-bold text-green-600 dark:text-green-400">
+              {{ completedCount }}
+            </span>
+          </div>
+          <span class="text-[10px] text-(--ui-text-muted)">completed</span>
+        </div>
+      </template>
       </div>
-      <span class="text-[10px] text-(--ui-text-muted)">completed</span>
-    </div>
+    </template>
   </div>
 </template>

--- a/app/components/StepTracker.vue
+++ b/app/components/StepTracker.vue
@@ -7,7 +7,6 @@ const props = withDefaults(defineProps<{
   distribution: StepDistribution[]
   completedCount?: number
   users?: ShopUser[]
-  stepAssignments?: Record<string, string | undefined>
 }>(), {
   completedCount: 0,
   users: () => [],
@@ -220,87 +219,87 @@ watch(() => props.distribution, () => nextTick(computeColumns))
         class="flex items-stretch gap-x-1"
         :class="row.length < columnsPerRow ? 'justify-center' : ''"
       >
-      <template
-        v-for="(item, colIdx) in row"
-        :key="item.type === 'step' ? item.step!.stepId : 'done'"
-      >
-        <!-- Arrow between cards (not before first in row) -->
-        <div
-          v-if="colIdx > 0"
-          class="flex items-center justify-center shrink-0"
+        <template
+          v-for="(item, colIdx) in row"
+          :key="item.type === 'step' ? item.step!.stepId : 'done'"
         >
-          <UIcon
-            name="i-lucide-chevron-right"
-            class="size-4 text-(--ui-text-muted)"
-          />
-        </div>
-
-        <!-- Step card -->
-        <div
-          v-if="item.type === 'step'"
-          class="flex flex-col items-center justify-center shrink-0 px-2 py-2.5 rounded border text-center cursor-pointer transition-colors hover:border-(--ui-primary) hover:bg-(--ui-primary)/5"
-          :class="stepBorderClass(item.step!)"
-          :style="{ width: `${cardWidth}px` }"
-          @click="handleStepClick(item.step!)"
-        >
-          <span class="text-[10px] text-(--ui-text-muted) mb-0.5 flex items-center gap-0.5">
-            Step {{ item.index + 1 }}
-            <UIcon
-              v-if="depIcon(getProcessStep(item.step!.stepId)?.dependencyType)"
-              :name="depIcon(getProcessStep(item.step!.stepId)?.dependencyType)!"
-              class="size-2.5"
-            />
-            <BottleneckBadge
-              v-if="item.step!.isBottleneck"
-              :is-bottleneck="true"
-            />
-          </span>
-          <span
-            class="text-xs font-medium text-(--ui-text-highlighted) text-center break-words"
-            :title="item.step!.stepName"
-          >{{ item.step!.stepName }}</span>
-          <span
-            v-if="item.step!.location"
-            class="text-[10px] text-(--ui-text-muted) text-center break-words"
-            :title="item.step!.location"
-          >{{ item.step!.location }}</span>
-          <span
-            v-if="getProcessStep(item.step!.stepId)?.optional"
-            class="text-[9px] text-(--ui-text-muted) italic"
-          >Optional</span>
-          <div class="mt-1 flex items-center gap-1 text-[10px] flex-wrap justify-center">
-            <span class="font-bold text-(--ui-text-highlighted)">{{ item.step!.partCount }}</span>
-            <span class="text-(--ui-text-muted)">at ·</span>
-            <span class="text-green-600 dark:text-green-400">{{ item.step!.completedCount }} done</span>
-          </div>
-          <span
-            v-if="users.length"
-            class="mt-1 text-[10px] text-(--ui-text-muted) text-center break-words"
-            :title="getProcessStep(item.step!.stepId)?.assignedTo ? users.find(u => u.id === getProcessStep(item.step!.stepId)?.assignedTo)?.displayName ?? 'Assigned' : 'Unassigned'"
+          <!-- Arrow between cards (not before first in row) -->
+          <div
+            v-if="colIdx > 0"
+            class="flex items-center justify-center shrink-0"
           >
-            👤 {{ getProcessStep(item.step!.stepId)?.assignedTo ? users.find(u => u.id === getProcessStep(item.step!.stepId)?.assignedTo)?.displayName ?? 'Assigned' : 'Unassigned' }}
-          </span>
-        </div>
+            <UIcon
+              name="i-lucide-chevron-right"
+              class="size-4 text-(--ui-text-muted)"
+            />
+          </div>
 
-        <!-- Done card -->
-        <div
-          v-else
-          class="flex flex-col items-center justify-center shrink-0 min-h-[100px] px-2 py-1.5 rounded border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-950/30 text-center"
-          :style="{ width: `${cardWidth}px` }"
-        >
-          <span class="text-[10px] text-(--ui-text-muted) mb-0.5">Done</span>
-          <UIcon
-            name="i-lucide-check-circle"
-            class="size-4 text-green-600 dark:text-green-400"
-          />
-          <div class="mt-1">
-            <span class="text-sm font-bold text-green-600 dark:text-green-400">
-              {{ completedCount }}
+          <!-- Step card -->
+          <div
+            v-if="item.type === 'step'"
+            class="flex flex-col items-center justify-center shrink-0 px-2 py-2.5 rounded border text-center cursor-pointer transition-colors hover:border-(--ui-primary) hover:bg-(--ui-primary)/5"
+            :class="stepBorderClass(item.step!)"
+            :style="{ width: `${cardWidth}px` }"
+            @click="handleStepClick(item.step!)"
+          >
+            <span class="text-[10px] text-(--ui-text-muted) mb-0.5 flex items-center gap-0.5">
+              Step {{ item.index + 1 }}
+              <UIcon
+                v-if="depIcon(getProcessStep(item.step!.stepId)?.dependencyType)"
+                :name="depIcon(getProcessStep(item.step!.stepId)?.dependencyType)!"
+                class="size-2.5"
+              />
+              <BottleneckBadge
+                v-if="item.step!.isBottleneck"
+                :is-bottleneck="true"
+              />
+            </span>
+            <span
+              class="text-xs font-medium text-(--ui-text-highlighted) text-center break-words"
+              :title="item.step!.stepName"
+            >{{ item.step!.stepName }}</span>
+            <span
+              v-if="item.step!.location"
+              class="text-[10px] text-(--ui-text-muted) text-center break-words"
+              :title="item.step!.location"
+            >{{ item.step!.location }}</span>
+            <span
+              v-if="getProcessStep(item.step!.stepId)?.optional"
+              class="text-[9px] text-(--ui-text-muted) italic"
+            >Optional</span>
+            <div class="mt-1 flex items-center gap-1 text-[10px] flex-wrap justify-center">
+              <span class="font-bold text-(--ui-text-highlighted)">{{ item.step!.partCount }}</span>
+              <span class="text-(--ui-text-muted)">at ·</span>
+              <span class="text-green-600 dark:text-green-400">{{ item.step!.completedCount }} done</span>
+            </div>
+            <span
+              v-if="users.length"
+              class="mt-1 text-[10px] text-(--ui-text-muted) text-center break-words"
+              :title="getProcessStep(item.step!.stepId)?.assignedTo ? users.find(u => u.id === getProcessStep(item.step!.stepId)?.assignedTo)?.displayName ?? 'Assigned' : 'Unassigned'"
+            >
+              👤 {{ getProcessStep(item.step!.stepId)?.assignedTo ? users.find(u => u.id === getProcessStep(item.step!.stepId)?.assignedTo)?.displayName ?? 'Assigned' : 'Unassigned' }}
             </span>
           </div>
-          <span class="text-[10px] text-(--ui-text-muted)">completed</span>
-        </div>
-      </template>
+
+          <!-- Done card -->
+          <div
+            v-else
+            class="flex flex-col items-center justify-center shrink-0 min-h-[100px] px-2 py-1.5 rounded border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-950/30 text-center"
+            :style="{ width: `${cardWidth}px` }"
+          >
+            <span class="text-[10px] text-(--ui-text-muted) mb-0.5">Done</span>
+            <UIcon
+              name="i-lucide-check-circle"
+              class="size-4 text-green-600 dark:text-green-400"
+            />
+            <div class="mt-1">
+              <span class="text-sm font-bold text-green-600 dark:text-green-400">
+                {{ completedCount }}
+              </span>
+            </div>
+            <span class="text-[10px] text-(--ui-text-muted)">completed</span>
+          </div>
+        </template>
       </div>
     </template>
   </div>

--- a/app/components/StepTracker.vue
+++ b/app/components/StepTracker.vue
@@ -285,7 +285,7 @@ watch(() => props.distribution, () => nextTick(computeColumns))
         <!-- Done card -->
         <div
           v-else
-          class="flex flex-col items-center justify-center shrink-0 px-2 py-1.5 rounded border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-950/30 text-center"
+          class="flex flex-col items-center justify-center shrink-0 min-h-[100px] px-2 py-1.5 rounded border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-950/30 text-center"
           :style="{ width: `${cardWidth}px` }"
         >
           <span class="text-[10px] text-(--ui-text-muted) mb-0.5">Done</span>

--- a/app/pages/parts/step/[stepId].vue
+++ b/app/pages/parts/step/[stepId].vue
@@ -228,7 +228,27 @@ onMounted(async () => {
       <!-- Step header -->
       <div class="space-y-2">
         <div class="flex items-center justify-between">
-          <div>
+          <div class="space-y-1">
+            <!-- Job + Path context (parent breadcrumb) -->
+            <div class="flex items-center gap-1.5 text-xs text-(--ui-text-muted)">
+              <NuxtLink
+                :to="`/jobs/${job.jobId}`"
+                class="inline-flex items-center gap-1 hover:text-(--ui-text-highlighted) transition-colors"
+              >
+                <UIcon
+                  name="i-lucide-briefcase"
+                  class="size-3.5"
+                />
+                {{ job.jobName }}
+              </NuxtLink>
+              <UIcon
+                name="i-lucide-chevron-right"
+                class="size-3 text-(--ui-text-dimmed)"
+              />
+              <span>{{ job.pathName }}</span>
+            </div>
+
+            <!-- Step name + position -->
             <div class="flex items-center gap-2">
               <h1 class="text-lg font-bold text-(--ui-text-highlighted)">
                 {{ job.stepName }}
@@ -245,13 +265,15 @@ onMounted(async () => {
                 @click="editing = true"
               />
             </div>
+
+            <!-- Step metadata (location, assignee) -->
             <p
-              v-if="!editing"
+              v-if="!editing && (job.stepLocation || assigneeName)"
               class="text-sm text-(--ui-text-muted)"
             >
-              {{ job.jobName }} · {{ job.pathName }}
-              <span v-if="job.stepLocation"> · 📍 {{ job.stepLocation }}</span>
-              <span v-if="assigneeName"> · 👤 {{ assigneeName }}</span>
+              <span v-if="job.stepLocation">📍 {{ job.stepLocation }}</span>
+              <span v-if="job.stepLocation && assigneeName"> · </span>
+              <span v-if="assigneeName">👤 {{ assigneeName }}</span>
             </p>
             <StepPropertiesEditor
               v-if="editing"

--- a/app/pages/parts/step/[stepId].vue
+++ b/app/pages/parts/step/[stepId].vue
@@ -226,85 +226,95 @@ onMounted(async () => {
     <!-- Step content -->
     <template v-else-if="job">
       <!-- Step header -->
-      <div class="space-y-2">
-        <div class="flex items-center justify-between">
-          <div class="space-y-1">
-            <!-- Job + Path context (parent breadcrumb) -->
-            <div class="flex items-center gap-1.5 text-xs text-(--ui-text-muted)">
-              <NuxtLink
-                :to="`/jobs/${job.jobId}`"
-                class="inline-flex items-center gap-1 hover:text-(--ui-text-highlighted) transition-colors"
-              >
-                <UIcon
-                  name="i-lucide-briefcase"
-                  class="size-3.5"
-                />
-                {{ job.jobName }}
-              </NuxtLink>
-              <UIcon
-                name="i-lucide-chevron-right"
-                class="size-3 text-(--ui-text-dimmed)"
-              />
-              <span>{{ job.pathName }}</span>
-            </div>
+      <div class="space-y-3">
+        <!-- Breadcrumb: Job (linked) › Path › Step -->
+        <UBreadcrumb
+          :items="[
+            { label: job.jobName, to: `/jobs/${job.jobId}`, icon: 'i-lucide-briefcase' },
+            { label: job.pathName, icon: 'i-lucide-git-branch' },
+            { label: job.stepName },
+          ]"
+        />
 
-            <!-- Step name + position -->
-            <div class="flex items-center gap-2">
-              <h1 class="text-lg font-bold text-(--ui-text-highlighted)">
-                {{ job.stepName }}
-              </h1>
-              <span class="text-xs text-(--ui-text-muted) bg-(--ui-bg-elevated) px-1.5 py-0.5 rounded">
-                Step {{ job.stepOrder + 1 }} of {{ job.totalSteps }}
-              </span>
-              <UButton
-                v-if="!editing"
-                size="xs"
-                variant="ghost"
-                icon="i-lucide-pencil"
-                aria-label="Edit step properties"
-                @click="editing = true"
-              />
-            </div>
-
-            <!-- Step metadata (location, assignee) -->
-            <p
-              v-if="!editing && (job.stepLocation || assigneeName)"
-              class="text-sm text-(--ui-text-muted)"
+        <!-- Title row: step name + prev/next -->
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex items-center gap-2 min-w-0">
+            <h1 class="text-xl font-semibold text-(--ui-text-highlighted) truncate">
+              {{ job.stepName }}
+            </h1>
+            <UButton
+              v-if="!editing"
+              size="xs"
+              variant="ghost"
+              color="neutral"
+              icon="i-lucide-pencil"
+              aria-label="Edit step properties"
+              @click="editing = true"
+            />
+          </div>
+          <div class="flex items-center gap-1 shrink-0">
+            <UButton
+              size="xs"
+              variant="ghost"
+              color="neutral"
+              icon="i-lucide-chevron-left"
+              aria-label="Previous step"
+              :disabled="job.stepOrder === 0"
+              :to="job.previousStepId ? `/parts/step/${job.previousStepId}` : undefined"
+            />
+            <UBadge
+              size="sm"
+              color="neutral"
+              variant="subtle"
             >
-              <span v-if="job.stepLocation">📍 {{ job.stepLocation }}</span>
-              <span v-if="job.stepLocation && assigneeName"> · </span>
-              <span v-if="assigneeName">👤 {{ assigneeName }}</span>
-            </p>
-            <StepPropertiesEditor
-              v-if="editing"
-              :step-id="job.stepId"
-              :current-assigned-to="job.assignedTo"
-              :current-location="job.stepLocation"
-              @saved="handleSaved"
-              @cancel="handleEditCancel"
+              {{ job.stepOrder + 1 }} / {{ job.totalSteps }}
+            </UBadge>
+            <UButton
+              size="xs"
+              variant="ghost"
+              color="neutral"
+              icon="i-lucide-chevron-right"
+              aria-label="Next step"
+              :disabled="job.isFinalStep"
+              :to="job.nextStepId ? `/parts/step/${job.nextStepId}` : undefined"
             />
           </div>
         </div>
 
-        <!-- Prev / Next step navigation -->
-        <div class="flex items-center justify-between">
-          <UButton
-            size="xs"
-            variant="ghost"
-            icon="i-lucide-arrow-left"
-            label="Prev"
-            :disabled="job.stepOrder === 0"
-            :to="job.previousStepId ? `/parts/step/${job.previousStepId}` : undefined"
-          />
-          <UButton
-            size="xs"
-            variant="ghost"
-            trailing-icon="i-lucide-arrow-right"
-            label="Next"
-            :disabled="job.isFinalStep"
-            :to="job.nextStepId ? `/parts/step/${job.nextStepId}` : undefined"
-          />
+        <!-- Metadata badges -->
+        <div
+          v-if="!editing && (job.stepLocation || assigneeName)"
+          class="flex items-center gap-1.5 flex-wrap"
+        >
+          <UBadge
+            v-if="job.stepLocation"
+            size="sm"
+            color="neutral"
+            variant="soft"
+            leading-icon="i-lucide-map-pin"
+          >
+            {{ job.stepLocation }}
+          </UBadge>
+          <UBadge
+            v-if="assigneeName"
+            size="sm"
+            color="neutral"
+            variant="soft"
+            leading-icon="i-lucide-user"
+          >
+            {{ assigneeName }}
+          </UBadge>
         </div>
+
+        <!-- Inline editor (replaces metadata when active) -->
+        <StepPropertiesEditor
+          v-if="editing"
+          :step-id="job.stepId"
+          :current-assigned-to="job.assignedTo"
+          :current-location="job.stepLocation"
+          @saved="handleSaved"
+          @cancel="handleEditCancel"
+        />
       </div>
 
       <!-- First step (always shows PartCreationPanel, even with 0 parts) -->

--- a/app/pages/parts/step/[stepId].vue
+++ b/app/pages/parts/step/[stepId].vue
@@ -149,19 +149,55 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="p-4 space-y-4 max-w-5xl">
-    <!-- Back link -->
+  <div class="px-4 pt-2 pb-4 space-y-3 max-w-5xl">
+    <!-- Back link + step stepper -->
     <ClientOnly>
-      <NuxtLink
-        :to="backNav.to"
-        class="inline-flex items-center gap-1 text-sm text-(--ui-text-muted) hover:text-(--ui-text-highlighted) transition-colors"
-      >
-        <UIcon
-          name="i-lucide-arrow-left"
-          class="size-4"
-        />
-        {{ backNav.label }}
-      </NuxtLink>
+      <div class="flex items-center justify-between">
+        <NuxtLink
+          :to="backNav.to"
+          class="inline-flex items-center gap-1 text-sm text-(--ui-text-muted) hover:text-(--ui-text-highlighted) transition-colors"
+        >
+          <UIcon
+            name="i-lucide-arrow-left"
+            class="size-4"
+          />
+          {{ backNav.label }}
+        </NuxtLink>
+        <div
+          v-if="job"
+          class="flex items-center gap-0.5 shrink-0 bg-primary/5 ring ring-inset ring-primary/15 rounded-lg p-0.5"
+        >
+          <UButton
+            size="sm"
+            variant="ghost"
+            color="primary"
+            icon="i-lucide-chevron-left"
+            aria-label="Previous step"
+            :disabled="job.stepOrder === 0"
+            :to="job.previousStepId ? `/parts/step/${job.previousStepId}` : undefined"
+          />
+          <USeparator
+            orientation="vertical"
+            class="h-4"
+          />
+          <span class="text-xs font-medium text-primary px-1.5 tabular-nums">
+            <span class="hidden sm:inline">Step </span>{{ job.stepOrder + 1 }} / {{ job.totalSteps }}
+          </span>
+          <USeparator
+            orientation="vertical"
+            class="h-4"
+          />
+          <UButton
+            size="sm"
+            variant="ghost"
+            color="primary"
+            icon="i-lucide-chevron-right"
+            aria-label="Next step"
+            :disabled="job.isFinalStep"
+            :to="job.nextStepId ? `/parts/step/${job.nextStepId}` : undefined"
+          />
+        </div>
+      </div>
       <template #fallback>
         <NuxtLink
           :to="fallbackPath"
@@ -241,7 +277,7 @@ onMounted(async () => {
     <!-- Step content -->
     <template v-else-if="job">
       <!-- Step header -->
-      <div class="space-y-3">
+      <div class="space-y-2">
         <!-- Breadcrumb: Job (linked) › Path › Step -->
         <UBreadcrumb
           :items="[
@@ -251,49 +287,20 @@ onMounted(async () => {
           ]"
         />
 
-        <!-- Title row: step name + prev/next -->
-        <div class="flex items-center justify-between gap-3">
-          <div class="flex items-center gap-2 min-w-0">
-            <h1 class="text-xl font-semibold text-(--ui-text-highlighted) truncate">
-              {{ job.stepName }}
-            </h1>
-            <UButton
-              v-if="!editing"
-              size="xs"
-              variant="ghost"
-              color="neutral"
-              icon="i-lucide-pencil"
-              aria-label="Edit step properties"
-              @click="editing = true"
-            />
-          </div>
-          <div class="flex items-center gap-1 shrink-0">
-            <UButton
-              size="xs"
-              variant="ghost"
-              color="neutral"
-              icon="i-lucide-chevron-left"
-              aria-label="Previous step"
-              :disabled="job.stepOrder === 0"
-              :to="job.previousStepId ? `/parts/step/${job.previousStepId}` : undefined"
-            />
-            <UBadge
-              size="sm"
-              color="neutral"
-              variant="subtle"
-            >
-              {{ job.stepOrder + 1 }} / {{ job.totalSteps }}
-            </UBadge>
-            <UButton
-              size="xs"
-              variant="ghost"
-              color="neutral"
-              icon="i-lucide-chevron-right"
-              aria-label="Next step"
-              :disabled="job.isFinalStep"
-              :to="job.nextStepId ? `/parts/step/${job.nextStepId}` : undefined"
-            />
-          </div>
+        <!-- Title row: step name -->
+        <div class="flex items-center gap-2 min-w-0">
+          <h1 class="text-xl font-semibold text-(--ui-text-highlighted) truncate">
+            {{ job.stepName }}
+          </h1>
+          <UButton
+            v-if="!editing"
+            size="xs"
+            variant="ghost"
+            color="neutral"
+            icon="i-lucide-pencil"
+            aria-label="Edit step properties"
+            @click="editing = true"
+          />
         </div>
 
         <!-- Metadata badges -->

--- a/app/pages/parts/step/[stepId].vue
+++ b/app/pages/parts/step/[stepId].vue
@@ -281,7 +281,7 @@ onMounted(async () => {
         <!-- Breadcrumb: Job (linked) › Path › Step -->
         <UBreadcrumb
           :items="[
-            { label: job.jobName, to: `/jobs/${job.jobId}`, icon: 'i-lucide-briefcase' },
+            { label: job.jobName, to: `/jobs/${encodeURIComponent(job.jobId)}`, icon: 'i-lucide-briefcase' },
             { label: job.pathName, icon: 'i-lucide-git-branch' },
             { label: job.stepName },
           ]"

--- a/server/api/operator/queue/_all.get.ts
+++ b/server/api/operator/queue/_all.get.ts
@@ -49,6 +49,7 @@ export default defineApiHandler(async () => {
           assignedTo: step.assignedTo,
           nextStepName: nextStep?.name,
           nextStepLocation: nextStep?.location,
+          nextStepAssignedTo: nextStep?.assignedTo,
           isFinalStep,
           jobPriority: job.priority,
           pathAdvancementMode: path.advancementMode,

--- a/server/api/operator/step/[stepId].get.ts
+++ b/server/api/operator/step/[stepId].get.ts
@@ -53,6 +53,7 @@ export default defineApiHandler(async (event) => {
           nextStepId: nextStep?.id,
           nextStepName: nextStep?.name,
           nextStepLocation: nextStep?.location,
+          nextStepAssignedTo: nextStep?.assignedTo,
           isFinalStep,
           stepOptional: step.optional ?? false,
           jobPriority: job.priority,

--- a/server/api/operator/work-queue.get.ts
+++ b/server/api/operator/work-queue.get.ts
@@ -57,6 +57,7 @@ export default defineApiHandler(async (event) => {
             assignedTo: step.assignedTo,
             nextStepName: nextStep?.name,
             nextStepLocation: nextStep?.location,
+            nextStepAssignedTo: nextStep?.assignedTo,
             isFinalStep,
             pathAdvancementMode: path.advancementMode,
             pathSteps,

--- a/server/types/computed.ts
+++ b/server/types/computed.ts
@@ -138,6 +138,7 @@ export interface WorkQueueJob {
   nextStepId?: string
   nextStepName?: string
   nextStepLocation?: string
+  nextStepAssignedTo?: string
   isFinalStep: boolean
   stepOptional?: boolean
   assignedTo?: string


### PR DESCRIPTION
Lots of UI and UX tweaks, fixes, and improvements.

Step View header redesign ([stepId].vue, PartCreationPanel.vue, ProcessAdvancementPanel.vue)

- Redesigned the step view header with proper hierarchy: parent job link, path name, step name with order badge
- Added "next step" assignee handoff info so operators can see who's up next
- API routes (step, work-queue, queue/_all) now return assignedToName in the response for display
- New assignedToName field on StepDistribution computed type
- StepTracker layout overhaul (StepTracker.vue)

- Replaced flex-wrap with a computed grid-row approach — a ResizeObserver calculates how many cards fit per row (120px min card width + arrow spacing) and chunks items into aligned rows
- Cards have a fixed computed width so columns align across rows, no more staggered boxes
- Partial rows are centered; arrows only appear between cards within a row, never orphaned at row ends
- Subtle <hr> divider between wrapped rows
- Step names and locations wrap (break-words) instead of truncating
- Bottleneck badge moved inline on the "Step N" header line
- Done card gets min-h-[100px] for visual consistency when alone on its own row
- Mobile layout (vertical stack) is separate and unchanged
