### PR TITLE
Prevent double click mistakes

### DIFF
--- a/app/components/JobPartsTab.vue
+++ b/app/components/JobPartsTab.vue
@@ -93,14 +93,10 @@ function onScrapped() {
   loadParts()
 }
 
-async function handleQuickAdvance(partId: string) {
-  try {
-    await $api('/api/parts/advance', { method: 'POST', body: { partIds: [partId] } })
-    await loadParts()
-  } catch {
-    // silent
-  }
-}
+const { execute: handleQuickAdvance, loading: advanceLoading } = useGuardedAction(async (partId: string) => {
+  await $api('/api/parts/advance', { method: 'POST', body: { partIds: [partId] } })
+  await loadParts()
+})
 
 onMounted(() => {
   loadParts()

--- a/app/components/JobPartsTab.vue
+++ b/app/components/JobPartsTab.vue
@@ -94,8 +94,12 @@ function onScrapped() {
 }
 
 const { execute: handleQuickAdvance, loading: advanceLoading } = useGuardedAction(async (partId: string) => {
-  await $api('/api/parts/advance', { method: 'POST', body: { partIds: [partId] } })
-  await loadParts()
+  try {
+    await $api('/api/parts/advance', { method: 'POST', body: { partIds: [partId] } })
+    await loadParts()
+  } catch {
+    // silent — inline quick-advance intentionally swallows errors
+  }
 })
 
 onMounted(() => {
@@ -249,6 +253,7 @@ onMounted(() => {
                   variant="ghost"
                   icon="i-lucide-arrow-right"
                   title="Advance"
+                  :loading="advanceLoading"
                   @click="handleQuickAdvance(s.id)"
                 />
                 <UButton
@@ -320,6 +325,7 @@ onMounted(() => {
             variant="ghost"
             icon="i-lucide-arrow-right"
             label="Advance"
+            :loading="advanceLoading"
             @click="handleQuickAdvance(s.id)"
           />
           <UButton

--- a/app/components/PartBatchForm.vue
+++ b/app/components/PartBatchForm.vue
@@ -16,7 +16,6 @@ const $api = useAuthFetch()
 
 const quantity = ref(1)
 const selectedCertId = ref<string | SelectNone>(SELECT_NONE)
-const saving = ref(false)
 const error = ref('')
 
 const certs = ref<Certificate[]>([])
@@ -38,7 +37,7 @@ const certOptions = computed(() => [
   ...certs.value.map(c => ({ label: `${c.name} (${c.type})`, value: c.id })),
 ])
 
-async function onSubmit() {
+const { execute: onSubmitInner, loading: saving } = useGuardedAction(async () => {
   error.value = ''
   if (!authenticatedUser.value) {
     error.value = 'Authentication required — please sign in again'
@@ -49,21 +48,22 @@ async function onSubmit() {
     return
   }
 
-  saving.value = true
+  const parts = await batchCreateParts({
+    jobId: props.jobId,
+    pathId: props.pathId,
+    quantity: quantity.value,
+    certId: selectedOrUndefined(selectedCertId.value),
+  })
+  quantity.value = 1
+  selectedCertId.value = SELECT_NONE
+  emit('created', parts)
+})
+
+async function onSubmit() {
   try {
-    const parts = await batchCreateParts({
-      jobId: props.jobId,
-      pathId: props.pathId,
-      quantity: quantity.value,
-      certId: selectedOrUndefined(selectedCertId.value),
-    })
-    quantity.value = 1
-    selectedCertId.value = SELECT_NONE
-    emit('created', parts)
+    await onSubmitInner()
   } catch (e) {
     error.value = e?.data?.message ?? e?.message ?? 'Failed to create parts'
-  } finally {
-    saving.value = false
   }
 }
 

--- a/app/components/StepNoteForm.vue
+++ b/app/components/StepNoteForm.vue
@@ -29,7 +29,7 @@ const canPushToJira = computed(() =>
   !!props.jiraTicketKey && !!props.jiraPushEnabled,
 )
 
-async function onSubmit() {
+const { execute: submitNote, loading: submitting } = useGuardedAction(async () => {
   const trimmed = text.value.trim()
   if (!trimmed) return
 
@@ -40,37 +40,42 @@ async function onSubmit() {
     localError.value = 'Authentication required — please sign in again'
     return
   }
-  try {
-    const note = await createNote({
-      jobId: props.jobId,
-      pathId: props.pathId,
-      stepId: props.stepId,
-      partIds: props.partIds,
-      text: trimmed,
-    })
 
-    // Push to Jira if checked
-    if (pushToJira.value && canPushToJira.value) {
-      pushingToJira.value = true
-      try {
-        const result = await pushNoteAsComment(props.jobId, note.id)
-        if (result.success) {
-          jiraPushResult.value = 'Pushed to Jira'
-        } else {
-          jiraPushResult.value = result.error ?? 'Jira push failed'
-          jiraPushIsError.value = true
-        }
-      } catch (e) {
-        jiraPushResult.value = e?.data?.message ?? e?.message ?? 'Jira push failed'
+  const note = await createNote({
+    jobId: props.jobId,
+    pathId: props.pathId,
+    stepId: props.stepId,
+    partIds: props.partIds,
+    text: trimmed,
+  })
+
+  // Push to Jira if checked
+  if (pushToJira.value && canPushToJira.value) {
+    pushingToJira.value = true
+    try {
+      const result = await pushNoteAsComment(props.jobId, note.id)
+      if (result.success) {
+        jiraPushResult.value = 'Pushed to Jira'
+      } else {
+        jiraPushResult.value = result.error ?? 'Jira push failed'
         jiraPushIsError.value = true
-      } finally {
-        pushingToJira.value = false
       }
+    } catch (e) {
+      jiraPushResult.value = e?.data?.message ?? e?.message ?? 'Jira push failed'
+      jiraPushIsError.value = true
+    } finally {
+      pushingToJira.value = false
     }
+  }
 
-    text.value = ''
-    pushToJira.value = false
-    emit('created', note)
+  text.value = ''
+  pushToJira.value = false
+  emit('created', note)
+})
+
+async function onSubmit() {
+  try {
+    await submitNote()
   } catch (e) {
     localError.value = e?.data?.message ?? e?.message ?? 'Failed to create note'
   }
@@ -119,7 +124,7 @@ async function onSubmit() {
           size="xs"
           label="Add Note"
           icon="i-lucide-message-square-plus"
-          :loading="loading || pushingToJira"
+          :loading="submitting || pushingToJira"
           :disabled="!text.trim()"
           @click="onSubmit"
         />

--- a/app/components/StepNoteForm.vue
+++ b/app/components/StepNoteForm.vue
@@ -14,7 +14,7 @@ const emit = defineEmits<{
   created: [note: StepNote]
 }>()
 
-const { createNote, loading, error } = useNotes()
+const { createNote, error } = useNotes()
 const { pushNoteAsComment } = useJira()
 const { authenticatedUser } = useAuth()
 

--- a/app/components/TagManager.vue
+++ b/app/components/TagManager.vue
@@ -22,13 +22,13 @@ const deleteRequiresForce = ref(false)
 
 onMounted(() => fetchTags())
 
-async function handleCreate() {
+const { execute: handleCreate } = useGuardedAction(async () => {
   const name = newName.value.trim()
   if (!name) return
   await createTag(name, newColor.value)
   newName.value = ''
   newColor.value = randomTagColor()
-}
+})
 
 function startEdit(tag: Tag) {
   editingId.value = tag.id
@@ -36,12 +36,12 @@ function startEdit(tag: Tag) {
   editColor.value = tag.color
 }
 
-async function saveEdit(id: string) {
+const { execute: saveEdit } = useGuardedAction(async (id: string) => {
   const name = editName.value.trim()
   if (!name) return
   await updateTag(id, { name, color: editColor.value })
   editingId.value = null
-}
+})
 
 function cancelEdit() {
   editingId.value = null

--- a/app/components/TagSelector.vue
+++ b/app/components/TagSelector.vue
@@ -17,7 +17,6 @@ const open = ref(false)
 const newTagName = ref('')
 const newTagColor = ref(randomTagColor())
 const showCreateForm = ref(false)
-const createLoading = ref(false)
 const createError = ref('')
 
 onMounted(() => fetchTags())
@@ -50,21 +49,22 @@ function removeTag(tagId: string) {
   emit('update:modelValue', props.modelValue.filter(id => id !== tagId))
 }
 
-async function handleCreateTag() {
+const { execute: handleCreateTagInner, loading: createLoading } = useGuardedAction(async () => {
   const name = newTagName.value.trim()
   if (!name) return
-  createLoading.value = true
   createError.value = ''
+  const tag = await createTag(name, newTagColor.value)
+  emit('update:modelValue', [...props.modelValue, tag.id])
+  newTagName.value = ''
+  newTagColor.value = randomTagColor()
+  showCreateForm.value = false
+})
+
+async function handleCreateTag() {
   try {
-    const tag = await createTag(name, newTagColor.value)
-    emit('update:modelValue', [...props.modelValue, tag.id])
-    newTagName.value = ''
-    newTagColor.value = randomTagColor()
-    showCreateForm.value = false
+    await handleCreateTagInner()
   } catch (e) {
     createError.value = extractApiError(e, 'Failed to create tag')
-  } finally {
-    createLoading.value = false
   }
 }
 </script>

--- a/app/pages/certs.vue
+++ b/app/pages/certs.vue
@@ -19,7 +19,7 @@ const batchSuccess = ref('')
 // Detail view state
 const selectedCertId = ref<string | null>(null)
 
-const { execute: onCreateCertInner, loading: formSaving } = useGuardedAction(async (data: { type: 'material' | 'process', name: string, metadata?: Record<string, unknown> }) => {
+const { execute: onCreateCertInner } = useGuardedAction(async (data: { type: 'material' | 'process', name: string, metadata?: Record<string, unknown> }) => {
   formError.value = ''
   await createCert(data)
   showForm.value = false

--- a/app/pages/certs.vue
+++ b/app/pages/certs.vue
@@ -6,7 +6,6 @@ const { authenticatedUser } = useAuth()
 
 // UI state
 const showForm = ref(false)
-const formSaving = ref(false)
 const formError = ref('')
 
 // Batch attach state
@@ -20,16 +19,17 @@ const batchSuccess = ref('')
 // Detail view state
 const selectedCertId = ref<string | null>(null)
 
-async function onCreateCert(data: { type: 'material' | 'process', name: string, metadata?: Record<string, unknown> }) {
+const { execute: onCreateCertInner, loading: formSaving } = useGuardedAction(async (data: { type: 'material' | 'process', name: string, metadata?: Record<string, unknown> }) => {
   formError.value = ''
-  formSaving.value = true
+  await createCert(data)
+  showForm.value = false
+})
+
+async function onCreateCert(data: { type: 'material' | 'process', name: string, metadata?: Record<string, unknown> }) {
   try {
-    await createCert(data)
-    showForm.value = false
+    await onCreateCertInner(data)
   } catch (e) {
     formError.value = e?.data?.message ?? e?.message ?? 'Failed to create certificate'
-  } finally {
-    formSaving.value = false
   }
 }
 

--- a/app/pages/parts/step/[stepId].vue
+++ b/app/pages/parts/step/[stepId].vue
@@ -23,7 +23,6 @@ const { advanceBatch } = useAdvanceBatch()
 const $api = useAuthFetch()
 const { users } = useAuth()
 
-const advanceLoading = ref(false)
 const editing = ref(false)
 const toast = useToast()
 
@@ -84,47 +83,48 @@ function handleEditCancel() {
   editing.value = false
 }
 
-async function handleAdvance(payload: { partIds: string[], note?: string }) {
+const { execute: handleAdvanceInner, loading: advanceLoading } = useGuardedAction(async (payload: { partIds: string[], note?: string }) => {
   if (!job.value) return
 
-  advanceLoading.value = true
-  try {
-    const result = await advanceBatch({
-      partIds: payload.partIds,
-      jobId: job.value.jobId,
-      pathId: job.value.pathId,
-      stepId: job.value.stepId,
-      availablePartCount: job.value.partCount,
-      note: payload.note,
+  const result = await advanceBatch({
+    partIds: payload.partIds,
+    jobId: job.value.jobId,
+    pathId: job.value.pathId,
+    stepId: job.value.stepId,
+    availablePartCount: job.value.partCount,
+    note: payload.note,
+  })
+
+  const dest = job.value.isFinalStep ? 'Completed' : (job.value.nextStepName ?? 'next step')
+
+  if (result.failed > 0) {
+    toast.add({
+      title: 'Partial advancement',
+      description: `${result.advanced} part${result.advanced !== 1 ? 's' : ''} moved to ${dest}, ${result.failed} failed`,
+      color: 'warning',
     })
+  } else {
+    toast.add({
+      title: 'Parts advanced',
+      description: `${result.advanced} part${result.advanced !== 1 ? 's' : ''} moved to ${dest}`,
+      color: 'success',
+    })
+  }
 
-    const dest = job.value.isFinalStep ? 'Completed' : (job.value.nextStepName ?? 'next step')
+  // Refresh step data
+  await fetchStep()
+  await fetchDeferredSteps()
+})
 
-    if (result.failed > 0) {
-      toast.add({
-        title: 'Partial advancement',
-        description: `${result.advanced} part${result.advanced !== 1 ? 's' : ''} moved to ${dest}, ${result.failed} failed`,
-        color: 'warning',
-      })
-    } else {
-      toast.add({
-        title: 'Parts advanced',
-        description: `${result.advanced} part${result.advanced !== 1 ? 's' : ''} moved to ${dest}`,
-        color: 'success',
-      })
-    }
-
-    // Refresh step data
-    await fetchStep()
-    await fetchDeferredSteps()
+async function handleAdvance(payload: { partIds: string[], note?: string }) {
+  try {
+    await handleAdvanceInner(payload)
   } catch (e) {
     toast.add({
       title: 'Advancement failed',
       description: e?.message ?? 'An error occurred',
       color: 'error',
     })
-  } finally {
-    advanceLoading.value = false
   }
 }
 


### PR DESCRIPTION
fix: guard 7 async button handlers against double-click with useGuardedAction

Wrap mutation-causing async click handlers with useGuardedAction to prevent duplicate server-side operations on rapid double-clicks:

- JobPartsTab.handleQuickAdvance (no guard at all — skips steps)
- parts/step/[stepId] handleAdvance (batch advance fires twice)
- PartBatchForm.onSubmit (creates 2x parts)
- StepNoteForm.onSubmit (duplicate notes)
- TagManager.handleCreate + saveEdit (duplicate tags)
- TagSelector.handleCreateTag (duplicate tags)
- certs.vue onCreateCert (duplicate certificates)

Fixes #141