### PR TITLE
feat: add Playwright e2e tests for business-critical flows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,47 @@
+name: E2E Tests
+
+# Opt-in: e2e is slow and flakier than the Vitest suite. Run it on demand
+# for risky or large PRs by adding the `run-e2e` label, or trigger manually.
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-e2e')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: npm run test:e2e
+        env:
+          CI: 'true'
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ data/
 .env
 *.swp
 .vscode
+
+# Playwright e2e artifacts
+test-results/
+playwright-report/
+blob-report/
+.playwright/

--- a/AI-MAP.md
+++ b/AI-MAP.md
@@ -108,6 +108,7 @@ tests/
     repositories/sqlite/ → 1 test file (migrations)
   properties/            → property-based tests (fast-check properties; see tests/properties for full list)
   integration/           → 16 files: helpers + 14 end-to-end lifecycle tests + jobViewUtilities integration tests
+  e2e/                   → Playwright business-critical flows (auth, job/path/part CRUD, advance/skip, deletion, admin guards). See TESTING.md for standards.
 ```
 
 ## Run Commands
@@ -117,8 +118,10 @@ tests/
 | Dev server | `npm run dev` | Nuxt dev with HMR |
 | Build | `npm run build` | Production build to `.output/` |
 | Preview | `npm run preview` | Preview production build locally |
-| Test | `npm run test` | `vitest run` |
+| Test | `npm run test` | `vitest run` (unit + integration + properties) |
 | Test watch | `npm run test:watch` | `vitest` in watch mode |
+| E2E test | `npm run test:e2e` | Playwright business-critical flows (see TESTING.md) |
+| E2E UI | `npm run test:e2e:ui` | Playwright interactive UI mode |
 | Lint | `npm run lint` | ESLint with Nuxt config |
 | Typecheck | `npm run typecheck` | `nuxt typecheck` |
 | Docker build | `docker build -t shop-erp .` | Requires `npm run build` first |

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,193 @@
+# Testing Standards
+
+This document defines how we test Shop Planr. Read it before adding or
+modifying any test. AI agents: treat this as durable instruction — don't
+deviate without explicit owner approval.
+
+## Scope by test type
+
+The codebase uses four test layers. Each layer has a clear purpose; duplicate
+coverage across layers is waste.
+
+| Layer            | Framework            | Location                    | What it validates                                                                 |
+|------------------|----------------------|-----------------------------|------------------------------------------------------------------------------------|
+| Unit             | Vitest               | `tests/unit/`               | Pure functions, utils, schema validation, isolated composables.                   |
+| Integration      | Vitest + SQLite      | `tests/integration/`        | Service-layer flows against in-memory SQLite — full repo → service wiring.        |
+| Property-based   | Vitest + fast-check  | `tests/properties/`         | Invariants: idempotence, round-trips, ordering, non-negative counts.              |
+| End-to-end (e2e) | Playwright + Chromium| `tests/e2e/`                | Business-critical user flows through the real UI and real HTTP stack.             |
+
+If a behavior can be verified at a lower layer, it belongs there. e2e is
+reserved for the handful of flows where UI wiring is itself the risk.
+
+## E2E scope — what we do and do not test
+
+The e2e suite is deliberately small. It covers **only** the flows a regression
+would take the product offline:
+
+- **Auth**: PIN setup, PIN login, switch user, log out.
+- **Job/path creation**: admin creates a job and adds paths.
+- **Parts**: create parts on a first step, advance parts between steps, skip
+  an optional step.
+- **Deletion**: admin deletes a path (empty + cascade), admin deletes a part.
+- **Access control**: non-admin users don't see creative/destructive buttons.
+
+**Out of scope for e2e** — covered elsewhere:
+
+- Validation error messages (unit tests on services/schemas).
+- Algorithms (property tests: advancement, distribution, grouping).
+- Multi-service workflows without UI branches (integration tests).
+- Visual regressions (use `npm run screenshots` for manual diffing).
+- Edge cases, error paths, retry logic, rate limiter behavior.
+
+**When adding an e2e test, ask: "If this breaks, can the app still ship?"** If
+the answer is yes, put it in a lower layer.
+
+## Running tests
+
+```bash
+npm run test              # Vitest: unit + integration + properties
+npm run test:watch        # Vitest in watch mode
+npm run test:e2e          # Playwright, headless
+npm run test:e2e:ui       # Playwright UI mode (interactive)
+npm run test:e2e:headed   # Watch the browser drive the UI
+npm run test:e2e:debug    # Step through with inspector
+```
+
+E2E runs against a dedicated DB: `./data/test.db`. The `global-setup` step
+deletes and re-seeds it before every run so tests start from a known state.
+Your dev DB (`./data/shop_erp.db`) is never touched.
+
+## E2E fixtures
+
+Use the shared fixtures in `tests/e2e/fixtures.ts` — don't roll your own
+auth.
+
+```ts
+import { test, expect } from './fixtures'
+
+test('something', async ({ adminPage })      => { /* ... */ })  // signed in as SAMPLE-Sarah (admin)
+test('something', async ({ operatorPage })   => { /* ... */ })  // signed in as SAMPLE-Mike  (non-admin)
+test('something', async ({ page, signInAs }) => {               // sign in mid-test
+  await signInAs('admin')
+})
+```
+
+## Standards for writing e2e tests
+
+1. **One behavior per test.** A test should fail for exactly one reason. If
+   you find yourself asserting 5 unrelated things, split the test.
+
+2. **Set up preconditions via the API, not the UI.** UI setup is slow and
+   couples the test to unrelated flows. Only drive the UI for the behavior
+   you're actually validating.
+
+   ```ts
+   // Good — API setup, UI for the thing under test:
+   const api = await apiAs(baseURL!, 'admin')
+   const { path } = await seedJobWithParts(api, { ... })
+   await adminPage.goto(`/jobs/${path.jobId}`)
+   await adminPage.getByRole('button', { name: 'Delete path' }).click()
+
+   // Bad — UI setup:
+   await adminPage.goto('/jobs/new')
+   await adminPage.getByTestId('job-name-input').fill(...)
+   // ... 20 more UI steps just to reach the delete button
+   ```
+
+3. **Prefer user-facing selectors over testids.** In order of preference:
+   `getByRole` → `getByLabel` → `getByText` → `getByTestId`. Only add a
+   `data-testid` when:
+   - multiple elements share the same role/text (disambiguation),
+   - the element has no accessible name (a blank icon button),
+   - the test would otherwise depend on copy that's likely to change.
+
+4. **Always use Playwright's web-first assertions.** `await expect(...)` auto-
+   retries. Never use `.evaluate()` to read state you could assert on, and
+   never `waitForTimeout(N)` as a stand-in for a real wait.
+
+5. **Dev-server pages are slow. Wait for `networkidle` once after
+   navigation, then rely on auto-waiting assertions** with a 10–20s timeout
+   for the first meaningful-paint. Don't sprinkle timeouts everywhere.
+
+6. **Keep selectors local.** Put testids on the component the test exercises,
+   not in a shared constants file. If a testid name shows up in more than 3
+   test files, you probably have a page-object opportunity — talk to the
+   owners before refactoring.
+
+7. **Don't assume ordering.** Tests run with `workers: 1` and a fresh DB per
+   run, but can be re-ordered by `--shard` or `--grep`. Never rely on data a
+   prior test created; create what you need.
+
+8. **Reserved seed users.** `SAMPLE-Sarah` (admin) and `SAMPLE-Mike`
+   (operator) are used by the fixtures — don't mutate their state (rename,
+   deactivate, etc.) from within a test. `SAMPLE-Tony` is reserved as the
+   "no-PIN-yet" user for the PIN-setup test. `SAMPLE-Lisa` is a free user
+   for custom flows.
+
+9. **Tolerate Nuxt UI toasts.** Toast text appears in several DOM nodes
+   (title, description, sr-only alert). Use `.first()` or target a more
+   specific element to avoid strict-mode violations.
+
+10. **Never add delays to make tests "stable".** Flakes are always a signal:
+    missing await, missing wait for a condition, race with a background
+    fetch. Fix the root cause.
+
+## Standards for Vitest tests
+
+1. **Unit tests go in `tests/unit/` mirroring the source tree.** One file per
+   source file: `server/utils/validation.ts` → `tests/unit/utils/validation.test.ts`.
+
+2. **Integration tests use `createTestContext()` from `tests/integration/helpers.ts`.**
+   Each test gets a fresh in-memory SQLite DB with migrations applied. Call
+   `cleanup()` in `afterEach`/`afterAll`.
+
+3. **Property tests live in `tests/properties/`.** Use `fast-check` for
+   invariants. Keep arbitraries small and readable; don't model the whole
+   domain — just what the property needs.
+
+4. **Don't mock business logic.** Integration tests run real services
+   against real repositories. Mock only external boundaries (Jira HTTP,
+   filesystem, clock when order matters).
+
+5. **Test names describe behavior, not implementation.** Read as a sentence:
+   `it('rejects advancement when part is scrapped')`, not
+   `it('advancePart returns error')`.
+
+## When to add a test
+
+| Change                                | Test layer                         |
+|---------------------------------------|------------------------------------|
+| New pure function / utility           | Unit                               |
+| New Zod schema / validator            | Unit (schema) + property (round-trip)|
+| New service method                    | Unit + integration for key flows   |
+| New API route                         | Unit (route handler) + integration if non-trivial business logic |
+| New domain invariant                  | Property                           |
+| New component with logic              | Unit (component test via happy-dom)|
+| New page — first time flow exists     | Consider 1 e2e happy-path test     |
+| Bug fix                               | Regression test at the layer where the bug lived |
+| Refactor with no behavior change      | No new test — existing tests should still pass |
+
+## When **not** to add an e2e test
+
+- The flow is already covered by a service-level integration test.
+- You're validating a validation error message, tooltip, or one-off copy.
+- The UI state is already asserted in a component-level unit test.
+- The feature is behind a feature flag and isn't on by default.
+- You want to "be safe". Safety comes from the right test at the right layer —
+  e2e is expensive and flaky. Use it sparingly.
+
+## Running CI
+
+- **`ci.yml`** — lint, typecheck, `npm run test`. Runs on every PR.
+- **`e2e.yml`** — Playwright suite. Opt-in via the `run-e2e` PR label, or
+  trigger manually via `workflow_dispatch`. Don't make this required on every
+  PR; the flake/cost ratio isn't worth it.
+
+## Debugging a failing e2e test
+
+1. Re-run with `npm run test:e2e:headed` to watch the browser.
+2. Check `test-results/<test-name>/` for screenshot, trace, and
+   `error-context.md` (DOM snapshot at failure).
+3. Open the trace: `npx playwright show-trace test-results/<test-name>/trace.zip`.
+4. If it's truly flaky (passes sometimes), treat it as a bug and fix the
+   root cause. Don't add retries to mask it.

--- a/app/components/AvatarPicker.vue
+++ b/app/components/AvatarPicker.vue
@@ -21,6 +21,8 @@ function getFirstName(displayName: string): string {
       :key="user.id"
       type="button"
       class="flex flex-col items-center gap-2 rounded-lg p-3 cursor-pointer transition-transform duration-150 hover:scale-110 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-primary-500"
+      data-testid="avatar-picker-user"
+      :data-username="user.username"
       @click="emit('select', user)"
     >
       <UserAvatar

--- a/app/components/JobCreationForm.vue
+++ b/app/components/JobCreationForm.vue
@@ -129,6 +129,7 @@ function handleCancel() {
           <label class="block text-sm font-medium text-(--ui-text-highlighted) mb-1">Job Name</label>
           <UInput
             v-model="jobDraft.name"
+            data-testid="job-name-input"
             placeholder="Enter job name"
             :color="getFieldError('job.name') ? 'error' : undefined"
             @update:model-value="clearFieldError('job.name')"
@@ -145,6 +146,7 @@ function handleCancel() {
           <label class="block text-sm font-medium text-(--ui-text-highlighted) mb-1">Goal Quantity</label>
           <UInput
             v-model.number="jobDraft.goalQuantity"
+            data-testid="job-goal-qty-input"
             type="number"
             :min="1"
             placeholder="1"
@@ -207,6 +209,7 @@ function handleCancel() {
               <label class="block text-xs font-medium text-(--ui-text-muted) mb-1">Path Name</label>
               <UInput
                 v-model="path.name"
+                :data-testid="`path-name-input-${pathIndex}`"
                 placeholder="Path name"
                 size="sm"
                 :color="getFieldError(`paths[${pathIndex}].name`) ? 'error' : undefined"
@@ -287,6 +290,7 @@ function handleCancel() {
     <!-- Submit / Cancel -->
     <div class="flex items-center gap-3 pt-4 border-t border-(--ui-border)">
       <UButton
+        data-testid="job-submit-btn"
         :label="mode === 'create' ? 'Create Job' : 'Save Changes'"
         :loading="submitting"
         :disabled="submitting"

--- a/app/components/ProcessLocationDropdown.vue
+++ b/app/components/ProcessLocationDropdown.vue
@@ -94,6 +94,7 @@ async function handleAddNew() {
   >
     <UInput
       :model-value="modelValue"
+      :data-testid="`process-location-input-${type}`"
       :placeholder="`Search ${type}...`"
       size="sm"
       class="w-full"

--- a/app/components/UserMenu.vue
+++ b/app/components/UserMenu.vue
@@ -24,7 +24,10 @@ const items: DropdownMenuItem[][] = [
     v-if="authenticatedUser"
     :items="items"
   >
-    <button class="flex items-center gap-2 cursor-pointer">
+    <button
+      class="flex items-center gap-2 cursor-pointer"
+      data-testid="user-menu-trigger"
+    >
       <UserAvatar
         :username="authenticatedUser.username"
         :display-name="authenticatedUser.displayName"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@nuxt/eslint": "^1.12.1",
         "@nuxt/test-utils": "^3.23.0",
+        "@playwright/test": "1.56.0",
         "@types/bcryptjs": "^2.4.6",
         "@types/better-sqlite3": "^7.6.13",
         "@vitest/coverage-v8": "^3.2.4",
@@ -1807,11 +1808,33 @@
         }
       }
     },
+    "node_modules/@nuxt/cli/node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nuxt/cli/node_modules/citty": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
       "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
       "license": "MIT"
+    },
+    "node_modules/@nuxt/cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@nuxt/cli/node_modules/giget": {
       "version": "3.2.0",
@@ -4209,6 +4232,56 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
+      "integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@polka/url": {
@@ -15679,6 +15752,19 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "typecheck": "nuxt typecheck",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "playwright test --debug",
     "seed": "npx tsx server/scripts/seed.ts",
     "seed:reset": "npx tsx server/scripts/seed.ts --reset",
     "screenshots": "npx tsx --env-file=.env scripts/screenshots.ts"
@@ -30,6 +34,7 @@
   "devDependencies": {
     "@nuxt/eslint": "^1.12.1",
     "@nuxt/test-utils": "^3.23.0",
+    "@playwright/test": "1.56.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/better-sqlite3": "^7.6.13",
     "@vitest/coverage-v8": "^3.2.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright config for Shop Planr e2e tests.
+ *
+ * Scope: business-critical flows only (auth, job/path/part CRUD, advancement).
+ * See TESTING.md for standards.
+ *
+ * - Isolates from the dev DB by pointing the server at ./data/test.db
+ * - Wipes + re-seeds the test DB before the suite via global-setup.ts
+ * - Auto-starts `nuxt dev` via webServer
+ */
+const PORT = Number(process.env.E2E_PORT ?? 3100)
+const BASE_URL = `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: /.*\.spec\.ts$/,
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 45_000,
+  expect: { timeout: 7_000 },
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  globalSetup: './tests/e2e/global-setup.ts',
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+    actionTimeout: 7_000,
+    navigationTimeout: 15_000,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    env: {
+      DB_PATH: './data/test.db',
+      PORT: String(PORT),
+      HOST: '127.0.0.1',
+      NUXT_DEVTOOLS_ENABLED: 'false',
+      // e2e fires many logins during the suite — the brute-force limiter
+      // (6/15s) would trip. Server honours this flag only in test/dev.
+      RATE_LIMIT_DISABLED: 'true',
+    },
+    // Poll the /api/users endpoint — `/` returns 426 while Nuxt dev is still
+    // warming up, but the Nitro server answers API routes as soon as it's
+    // ready, which is what the tests actually need.
+    url: `${BASE_URL}/api/users`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -55,7 +55,10 @@ export default defineConfig({
     // warming up, but the Nitro server answers API routes as soon as it's
     // ready, which is what the tests actually need.
     url: `${BASE_URL}/api/users`,
-    reuseExistingServer: !process.env.CI,
+    // Default to launching a fresh server so we guarantee the test DB/env.
+    // Set REUSE_E2E_SERVER=true to skip startup when you've already started
+    // the server with the correct e2e env (DB_PATH, RATE_LIMIT_DISABLED, etc).
+    reuseExistingServer: process.env.REUSE_E2E_SERVER === 'true',
     timeout: 120_000,
     stdout: 'pipe',
     stderr: 'pipe',

--- a/server/middleware/01.rateLimit.ts
+++ b/server/middleware/01.rateLimit.ts
@@ -33,6 +33,13 @@ export default defineEventHandler(async (event) => {
     return
   }
 
+  // Escape hatch for e2e test runs: set RATE_LIMIT_DISABLED=true in the
+  // webServer env to bypass brute-force protection while driving the UI.
+  // Never set this in production.
+  if (process.env.RATE_LIMIT_DISABLED === 'true') {
+    return
+  }
+
   // Determine auth status from Authorization header (runs before auth middleware)
   const authHeader = getHeader(event, 'authorization')
   const isAuthenticated = !!authHeader?.startsWith('Bearer ')

--- a/server/middleware/01.rateLimit.ts
+++ b/server/middleware/01.rateLimit.ts
@@ -35,8 +35,9 @@ export default defineEventHandler(async (event) => {
 
   // Escape hatch for e2e test runs: set RATE_LIMIT_DISABLED=true in the
   // webServer env to bypass brute-force protection while driving the UI.
-  // Never set this in production.
-  if (process.env.RATE_LIMIT_DISABLED === 'true') {
+  // Gated behind import.meta.dev so it's dead-code-eliminated in production
+  // builds — even if the env var leaks, it can never disable rate limiting.
+  if (import.meta.dev && process.env.RATE_LIMIT_DISABLED === 'true') {
     return
   }
 

--- a/server/repositories/sqlite/index.ts
+++ b/server/repositories/sqlite/index.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3'
 import { createHash } from 'crypto'
-import { existsSync, readdirSync, readFileSync } from 'fs'
-import { join, resolve } from 'path'
+import { existsSync, mkdirSync, readdirSync, readFileSync } from 'fs'
+import { dirname, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { SQLiteJobRepository } from './jobRepository'
 import { SQLitePathRepository } from './pathRepository'
@@ -168,6 +168,11 @@ export function runMigrations(db: Database.Database, migrationsDir?: string): vo
  * Initialize a SQLite database with WAL mode, foreign keys, and run all migrations.
  */
 export function initDatabase(dbPath: string, migrationsDir?: string): Database.Database {
+  // Ensure the parent directory exists — better-sqlite3 won't create it.
+  const dir = dirname(dbPath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
   const db = new Database(dbPath)
   db.pragma('journal_mode = WAL')
   db.pragma('foreign_keys = ON')

--- a/tests/e2e/access-control.spec.ts
+++ b/tests/e2e/access-control.spec.ts
@@ -25,16 +25,20 @@ test.describe('access control', () => {
 
   test('non-admin does not see the "Delete Part" button on part detail', async ({ operatorPage, baseURL }) => {
     const api = await apiAs(baseURL!, 'admin')
-    const { parts } = await seedJobWithParts(api, {
-      jobName: `E2E Guard-Part ${Date.now()}`,
-      partQuantity: 1,
-    })
-    const partId = parts[0]!.id
+    try {
+      const { parts } = await seedJobWithParts(api, {
+        jobName: `E2E Guard-Part ${Date.now()}`,
+        partQuantity: 1,
+      })
+      const partId = parts[0]!.id
 
-    await operatorPage.goto(`/parts-browser/${partId}`)
-    await expect(operatorPage.getByRole('heading', { name: partId })).toBeVisible({ timeout: 10_000 })
-    await operatorPage.waitForLoadState('networkidle')
+      await operatorPage.goto(`/parts-browser/${partId}`)
+      await expect(operatorPage.getByRole('heading', { name: partId })).toBeVisible({ timeout: 10_000 })
+      await operatorPage.waitForLoadState('networkidle')
 
-    await expect(operatorPage.getByRole('button', { name: 'Delete Part', exact: true })).toHaveCount(0)
+      await expect(operatorPage.getByRole('button', { name: 'Delete Part', exact: true })).toHaveCount(0)
+    } finally {
+      await api.dispose()
+    }
   })
 })

--- a/tests/e2e/access-control.spec.ts
+++ b/tests/e2e/access-control.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Access-control e2e: admin gates for create/delete.
+ *
+ * Non-admin users should never see destructive or creative controls. The UI
+ * hides them via `useAuth().isAdmin`; the server also enforces via 403 —
+ * these tests cover the client side so regressions surface early.
+ */
+import { test, expect } from './fixtures'
+import { apiAs, seedJobWithParts } from './helpers/api'
+
+test.describe('access control', () => {
+  test('non-admin does not see the "New Job" button on /jobs', async ({ operatorPage }) => {
+    await operatorPage.goto('/jobs')
+    await expect(operatorPage.getByRole('heading', { name: 'Jobs' })).toBeVisible()
+    await operatorPage.waitForLoadState('networkidle')
+
+    await expect(operatorPage.getByRole('button', { name: 'New Job' })).toHaveCount(0)
+  })
+
+  test('non-admin visiting /jobs/new is redirected away', async ({ operatorPage }) => {
+    await operatorPage.goto('/jobs/new')
+    // Guard runs in onMounted and navigates to /jobs.
+    await expect(operatorPage).toHaveURL(/\/jobs$/, { timeout: 10_000 })
+  })
+
+  test('non-admin does not see the "Delete Part" button on part detail', async ({ operatorPage, baseURL }) => {
+    const api = await apiAs(baseURL!, 'admin')
+    const { parts } = await seedJobWithParts(api, {
+      jobName: `E2E Guard-Part ${Date.now()}`,
+      partQuantity: 1,
+    })
+    const partId = parts[0]!.id
+
+    await operatorPage.goto(`/parts-browser/${partId}`)
+    await expect(operatorPage.getByRole('heading', { name: partId })).toBeVisible({ timeout: 10_000 })
+    await operatorPage.waitForLoadState('networkidle')
+
+    await expect(operatorPage.getByRole('button', { name: 'Delete Part', exact: true })).toHaveCount(0)
+  })
+})

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -9,8 +9,32 @@ import { TEST_USERS, AUTH_COOKIE, UNREGISTERED_USERNAME } from './helpers/auth'
 
 async function enterPin(page: import('@playwright/test').Page, pin: string) {
   for (let i = 0; i < 4; i++) {
-    await page.getByLabel(`PIN digit ${i + 1}`).fill(pin[i]!)
+    const input = page.getByLabel(`PIN digit ${i + 1}`)
+    await input.click()
+    await input.pressSequentially(pin[i]!)
   }
+}
+
+/**
+ * After login/setupPin the app calls window.location.reload(). The Teleport-
+ * based overlay can sometimes persist through the hydration cycle, so we
+ * wait for the cookie to appear (proving the auth API succeeded) and then
+ * do a clean navigation to let SSR render the authenticated state.
+ */
+async function waitForAuthAndNavigate(
+  page: import('@playwright/test').Page,
+  context: import('@playwright/test').BrowserContext,
+) {
+  // The reload fires asynchronously — give it a moment to set the cookie.
+  await page.waitForTimeout(1_000)
+  await expect(async () => {
+    const cookies = await context.cookies()
+    expect(cookies.some(c => c.name === AUTH_COOKIE && c.value)).toBe(true)
+  }).toPass({ timeout: 10_000 })
+
+  // Fresh navigation ensures clean SSR with the auth cookie.
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
 }
 
 test.describe('authentication', () => {
@@ -26,6 +50,8 @@ test.describe('authentication', () => {
     // PinSetup renders two sequential PinEntry instances (create then confirm).
     await enterPin(page, '1234')
     await enterPin(page, '1234')
+
+    await waitForAuthAndNavigate(page, context)
 
     await expect(page.getByTestId('user-menu-trigger')).toBeVisible({ timeout: 10_000 })
     await expect(page.getByTestId('user-menu-trigger')).toContainText(UNREGISTERED_USERNAME)
@@ -55,6 +81,8 @@ test.describe('authentication', () => {
     await sarahAvatar.click()
     await expect(page.getByText(/enter your pin/i)).toBeVisible()
     await enterPin(page, TEST_USERS.admin.pin)
+
+    await waitForAuthAndNavigate(page, context)
 
     await expect(page.getByTestId('user-menu-trigger')).toBeVisible({ timeout: 10_000 })
   })

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -36,12 +36,15 @@ test.describe('authentication', () => {
 
   test('existing user logs in with PIN', async ({ page, context, request }) => {
     // Ensure Sarah has a PIN (idempotent — may already be set by a fixture).
-    const users = await (await request.get('/api/users')).json()
+    const usersRes = await request.get('/api/users')
+    expect(usersRes.ok(), `GET /api/users failed: ${usersRes.status()} ${await usersRes.text()}`).toBe(true)
+    const users = await usersRes.json()
     const sarah = users.find((u: { username: string, hasPin: boolean }) => u.username === TEST_USERS.admin.username)
     if (sarah && !sarah.hasPin) {
-      await request.post('/api/auth/setup-pin', {
+      const pinRes = await request.post('/api/auth/setup-pin', {
         data: { userId: sarah.id, pin: TEST_USERS.admin.pin },
       })
+      expect(pinRes.ok(), `POST /api/auth/setup-pin failed: ${pinRes.status()} ${await pinRes.text()}`).toBe(true)
     }
 
     await context.clearCookies()

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Auth e2e: kiosk login, PIN setup, switch user.
+ *
+ * Non-goals: invalid PIN retry limits (covered by service tests), token
+ * refresh (covered by unit tests).
+ */
+import { test, expect } from './fixtures'
+import { TEST_USERS, AUTH_COOKIE, UNREGISTERED_USERNAME } from './helpers/auth'
+
+async function enterPin(page: import('@playwright/test').Page, pin: string) {
+  for (let i = 0; i < 4; i++) {
+    await page.getByLabel(`PIN digit ${i + 1}`).fill(pin[i]!)
+  }
+}
+
+test.describe('authentication', () => {
+  test('new user sets up a PIN and lands signed in', async ({ page, context }) => {
+    await context.clearCookies()
+    await page.goto('/')
+
+    // Users are fetched client-side after mount — wait for the avatar grid.
+    const tonyAvatar = page.locator(`[data-testid="avatar-picker-user"][data-username="${UNREGISTERED_USERNAME}"]`)
+    await expect(tonyAvatar).toBeVisible({ timeout: 15_000 })
+    await tonyAvatar.click()
+
+    // PinSetup renders two sequential PinEntry instances (create then confirm).
+    await enterPin(page, '1234')
+    await enterPin(page, '1234')
+
+    await expect(page.getByTestId('user-menu-trigger')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('user-menu-trigger')).toContainText(UNREGISTERED_USERNAME)
+
+    const cookies = await context.cookies()
+    expect(cookies.some(c => c.name === AUTH_COOKIE && c.value)).toBe(true)
+  })
+
+  test('existing user logs in with PIN', async ({ page, context, request }) => {
+    // Ensure Sarah has a PIN (idempotent — may already be set by a fixture).
+    const users = await (await request.get('/api/users')).json()
+    const sarah = users.find((u: { username: string, hasPin: boolean }) => u.username === TEST_USERS.admin.username)
+    if (sarah && !sarah.hasPin) {
+      await request.post('/api/auth/setup-pin', {
+        data: { userId: sarah.id, pin: TEST_USERS.admin.pin },
+      })
+    }
+
+    await context.clearCookies()
+    await page.goto('/')
+
+    const sarahAvatar = page.locator(`[data-testid="avatar-picker-user"][data-username="${TEST_USERS.admin.username}"]`)
+    await expect(sarahAvatar).toBeVisible()
+    await sarahAvatar.click()
+    await expect(page.getByText(/enter your pin/i)).toBeVisible()
+    await enterPin(page, TEST_USERS.admin.pin)
+
+    await expect(page.getByTestId('user-menu-trigger')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('switch user clears session and returns to picker', async ({ adminPage }) => {
+    await adminPage.goto('/')
+    const trigger = adminPage.getByTestId('user-menu-trigger')
+    await expect(trigger).toBeVisible()
+    await adminPage.waitForLoadState('networkidle')
+
+    await trigger.click()
+    const menuItem = adminPage.getByRole('menuitem', { name: /switch user/i })
+    await expect(menuItem).toBeVisible({ timeout: 5_000 })
+    await menuItem.click()
+
+    await expect(adminPage.getByText('Select a user')).toBeVisible()
+    await expect(trigger).not.toBeVisible()
+  })
+
+  test('log out clears the session', async ({ adminPage, context }) => {
+    await adminPage.goto('/')
+    const trigger = adminPage.getByTestId('user-menu-trigger')
+    await expect(trigger).toBeVisible()
+    await adminPage.waitForLoadState('networkidle')
+
+    await trigger.click()
+    const menuItem = adminPage.getByRole('menuitem', { name: /log out/i })
+    await expect(menuItem).toBeVisible({ timeout: 5_000 })
+    await menuItem.click()
+
+    await expect(adminPage.getByText('Select a user')).toBeVisible()
+    const cookies = await context.cookies()
+    const stillAuthed = cookies.some(c => c.name === AUTH_COOKIE && c.value)
+    expect(stillAuthed).toBe(false)
+  })
+})

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -25,8 +25,7 @@ async function waitForAuthAndNavigate(
   page: import('@playwright/test').Page,
   context: import('@playwright/test').BrowserContext,
 ) {
-  // The reload fires asynchronously — give it a moment to set the cookie.
-  await page.waitForTimeout(1_000)
+  // The reload fires asynchronously — poll until the cookie appears.
   await expect(async () => {
     const cookies = await context.cookies()
     expect(cookies.some(c => c.name === AUTH_COOKIE && c.value)).toBe(true)

--- a/tests/e2e/deletion.spec.ts
+++ b/tests/e2e/deletion.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Deletion e2e: admin-only destructive operations.
+ *
+ * Covers the path and part delete flows, including the cascade-confirmation
+ * modal that appears when a path has parts.
+ */
+import { test, expect } from './fixtures'
+import { apiAs, seedJobWithParts, createJob, createPath } from './helpers/api'
+
+test.describe('deletion', () => {
+  test('admin deletes an empty path via inline confirmation', async ({ adminPage, baseURL }) => {
+    const api = await apiAs(baseURL!, 'admin')
+    const job = await createJob(api, { name: `E2E Delete-Path ${Date.now()}`, goalQuantity: 5 })
+    const path = await createPath(api, {
+      jobId: job.id,
+      name: 'Scratch',
+      goalQuantity: 5,
+      steps: [{ name: 'CNC Machine' }],
+    })
+
+    await adminPage.goto(`/jobs/${job.id}`)
+    await expect(adminPage.getByText(path.name)).toBeVisible({ timeout: 10_000 })
+    await adminPage.waitForLoadState('networkidle')
+
+    // For a path with zero parts PathDeleteButton goes through a two-click
+    // inline confirmation (no modal). The trash icon is a button with
+    // title "Delete path".
+    await adminPage.getByRole('button', { name: 'Delete path' }).first().click()
+    await adminPage.getByRole('button', { name: 'Yes', exact: true }).click()
+
+    await expect(adminPage.getByText(path.name)).not.toBeVisible({ timeout: 10_000 })
+  })
+
+  test('admin deletes a path with parts via cascade modal', async ({ adminPage, baseURL }) => {
+    const api = await apiAs(baseURL!, 'admin')
+    const { job, path } = await seedJobWithParts(api, {
+      jobName: `E2E Delete-Cascade ${Date.now()}`,
+      pathName: 'Cascade',
+      partQuantity: 2,
+    })
+
+    await adminPage.goto(`/jobs/${job.id}`)
+    // 'Cascade' may appear both in the path name and in step/location fields —
+    // first match is the path header, which is what we care about.
+    await expect(adminPage.getByText(path.name).first()).toBeVisible({ timeout: 10_000 })
+    await adminPage.waitForLoadState('networkidle')
+
+    await adminPage.getByRole('button', { name: 'Delete path' }).first().click()
+
+    // With parts present, the button opens a confirmation modal.
+    const deleteBtn = adminPage.getByRole('dialog').getByRole('button', { name: 'Delete', exact: true })
+    await expect(deleteBtn).toBeVisible({ timeout: 5_000 })
+    await deleteBtn.click()
+
+    // Path list re-renders — the former path name is gone from the page.
+    await expect(adminPage.getByText(path.name)).toHaveCount(0, { timeout: 10_000 })
+  })
+
+  test('admin deletes a part from the part detail page', async ({ adminPage, baseURL }) => {
+    const api = await apiAs(baseURL!, 'admin')
+    const { parts } = await seedJobWithParts(api, {
+      jobName: `E2E Delete-Part ${Date.now()}`,
+      partQuantity: 1,
+    })
+    const partId = parts[0]!.id
+
+    await adminPage.goto(`/parts-browser/${partId}`)
+    await expect(adminPage.getByRole('heading', { name: partId })).toBeVisible({ timeout: 10_000 })
+    await adminPage.waitForLoadState('networkidle')
+
+    // Open the delete modal — Delete Part button is admin-only.
+    await adminPage.getByRole('button', { name: 'Delete Part', exact: true }).click()
+
+    const confirmBtn = adminPage.getByRole('dialog').getByRole('button', { name: 'Delete', exact: true })
+    await expect(confirmBtn).toBeVisible({ timeout: 5_000 })
+    await confirmBtn.click()
+
+    // After delete, we're sent back to the browser.
+    await expect(adminPage).toHaveURL(/\/parts-browser$/, { timeout: 10_000 })
+
+    // Verify server-side: the part is gone.
+    const res = await api.request.get(`/api/parts/${partId}`)
+    expect(res.status()).toBe(404)
+  })
+})

--- a/tests/e2e/deletion.spec.ts
+++ b/tests/e2e/deletion.spec.ts
@@ -29,7 +29,9 @@ test.describe('deletion', () => {
       await adminPage.getByRole('button', { name: 'Delete path' }).first().click()
       await adminPage.getByRole('button', { name: 'Yes', exact: true }).click()
 
-      await expect(adminPage.getByText(path.name)).not.toBeVisible({ timeout: 10_000 })
+      // After deletion the path name should no longer appear in the path list.
+      // Use exact match to avoid matching the delete confirmation text.
+      await expect(adminPage.getByText(path.name, { exact: true })).not.toBeVisible({ timeout: 10_000 })
     } finally {
       await api.dispose()
     }
@@ -58,7 +60,7 @@ test.describe('deletion', () => {
       await deleteBtn.click()
 
       // Path list re-renders — the former path name is gone from the page.
-      await expect(adminPage.getByText(path.name)).toHaveCount(0, { timeout: 10_000 })
+      await expect(adminPage.getByText(path.name, { exact: true })).toHaveCount(0, { timeout: 10_000 })
     } finally {
       await api.dispose()
     }

--- a/tests/e2e/deletion.spec.ts
+++ b/tests/e2e/deletion.spec.ts
@@ -10,76 +10,88 @@ import { apiAs, seedJobWithParts, createJob, createPath } from './helpers/api'
 test.describe('deletion', () => {
   test('admin deletes an empty path via inline confirmation', async ({ adminPage, baseURL }) => {
     const api = await apiAs(baseURL!, 'admin')
-    const job = await createJob(api, { name: `E2E Delete-Path ${Date.now()}`, goalQuantity: 5 })
-    const path = await createPath(api, {
-      jobId: job.id,
-      name: 'Scratch',
-      goalQuantity: 5,
-      steps: [{ name: 'CNC Machine' }],
-    })
+    try {
+      const job = await createJob(api, { name: `E2E Delete-Path ${Date.now()}`, goalQuantity: 5 })
+      const path = await createPath(api, {
+        jobId: job.id,
+        name: 'Scratch',
+        goalQuantity: 5,
+        steps: [{ name: 'CNC Machine' }],
+      })
 
-    await adminPage.goto(`/jobs/${job.id}`)
-    await expect(adminPage.getByText(path.name)).toBeVisible({ timeout: 10_000 })
-    await adminPage.waitForLoadState('networkidle')
+      await adminPage.goto(`/jobs/${job.id}`)
+      await expect(adminPage.getByText(path.name)).toBeVisible({ timeout: 10_000 })
+      await adminPage.waitForLoadState('networkidle')
 
-    // For a path with zero parts PathDeleteButton goes through a two-click
-    // inline confirmation (no modal). The trash icon is a button with
-    // title "Delete path".
-    await adminPage.getByRole('button', { name: 'Delete path' }).first().click()
-    await adminPage.getByRole('button', { name: 'Yes', exact: true }).click()
+      // For a path with zero parts PathDeleteButton goes through a two-click
+      // inline confirmation (no modal). The trash icon is a button with
+      // title "Delete path".
+      await adminPage.getByRole('button', { name: 'Delete path' }).first().click()
+      await adminPage.getByRole('button', { name: 'Yes', exact: true }).click()
 
-    await expect(adminPage.getByText(path.name)).not.toBeVisible({ timeout: 10_000 })
+      await expect(adminPage.getByText(path.name)).not.toBeVisible({ timeout: 10_000 })
+    } finally {
+      await api.dispose()
+    }
   })
 
   test('admin deletes a path with parts via cascade modal', async ({ adminPage, baseURL }) => {
     const api = await apiAs(baseURL!, 'admin')
-    const { job, path } = await seedJobWithParts(api, {
-      jobName: `E2E Delete-Cascade ${Date.now()}`,
-      pathName: 'Cascade',
-      partQuantity: 2,
-    })
+    try {
+      const { job, path } = await seedJobWithParts(api, {
+        jobName: `E2E Delete-Cascade ${Date.now()}`,
+        pathName: 'Cascade',
+        partQuantity: 2,
+      })
 
-    await adminPage.goto(`/jobs/${job.id}`)
-    // 'Cascade' may appear both in the path name and in step/location fields —
-    // first match is the path header, which is what we care about.
-    await expect(adminPage.getByText(path.name).first()).toBeVisible({ timeout: 10_000 })
-    await adminPage.waitForLoadState('networkidle')
+      await adminPage.goto(`/jobs/${job.id}`)
+      // 'Cascade' may appear both in the path name and in step/location fields —
+      // first match is the path header, which is what we care about.
+      await expect(adminPage.getByText(path.name).first()).toBeVisible({ timeout: 10_000 })
+      await adminPage.waitForLoadState('networkidle')
 
-    await adminPage.getByRole('button', { name: 'Delete path' }).first().click()
+      await adminPage.getByRole('button', { name: 'Delete path' }).first().click()
 
-    // With parts present, the button opens a confirmation modal.
-    const deleteBtn = adminPage.getByRole('dialog').getByRole('button', { name: 'Delete', exact: true })
-    await expect(deleteBtn).toBeVisible({ timeout: 5_000 })
-    await deleteBtn.click()
+      // With parts present, the button opens a confirmation modal.
+      const deleteBtn = adminPage.getByRole('dialog').getByRole('button', { name: 'Delete', exact: true })
+      await expect(deleteBtn).toBeVisible({ timeout: 5_000 })
+      await deleteBtn.click()
 
-    // Path list re-renders — the former path name is gone from the page.
-    await expect(adminPage.getByText(path.name)).toHaveCount(0, { timeout: 10_000 })
+      // Path list re-renders — the former path name is gone from the page.
+      await expect(adminPage.getByText(path.name)).toHaveCount(0, { timeout: 10_000 })
+    } finally {
+      await api.dispose()
+    }
   })
 
   test('admin deletes a part from the part detail page', async ({ adminPage, baseURL }) => {
     const api = await apiAs(baseURL!, 'admin')
-    const { parts } = await seedJobWithParts(api, {
-      jobName: `E2E Delete-Part ${Date.now()}`,
-      partQuantity: 1,
-    })
-    const partId = parts[0]!.id
+    try {
+      const { parts } = await seedJobWithParts(api, {
+        jobName: `E2E Delete-Part ${Date.now()}`,
+        partQuantity: 1,
+      })
+      const partId = parts[0]!.id
 
-    await adminPage.goto(`/parts-browser/${partId}`)
-    await expect(adminPage.getByRole('heading', { name: partId })).toBeVisible({ timeout: 10_000 })
-    await adminPage.waitForLoadState('networkidle')
+      await adminPage.goto(`/parts-browser/${partId}`)
+      await expect(adminPage.getByRole('heading', { name: partId })).toBeVisible({ timeout: 10_000 })
+      await adminPage.waitForLoadState('networkidle')
 
-    // Open the delete modal — Delete Part button is admin-only.
-    await adminPage.getByRole('button', { name: 'Delete Part', exact: true }).click()
+      // Open the delete modal — Delete Part button is admin-only.
+      await adminPage.getByRole('button', { name: 'Delete Part', exact: true }).click()
 
-    const confirmBtn = adminPage.getByRole('dialog').getByRole('button', { name: 'Delete', exact: true })
-    await expect(confirmBtn).toBeVisible({ timeout: 5_000 })
-    await confirmBtn.click()
+      const confirmBtn = adminPage.getByRole('dialog').getByRole('button', { name: 'Delete', exact: true })
+      await expect(confirmBtn).toBeVisible({ timeout: 5_000 })
+      await confirmBtn.click()
 
-    // After delete, we're sent back to the browser.
-    await expect(adminPage).toHaveURL(/\/parts-browser$/, { timeout: 10_000 })
+      // After delete, we're sent back to the browser.
+      await expect(adminPage).toHaveURL(/\/parts-browser$/, { timeout: 10_000 })
 
-    // Verify server-side: the part is gone.
-    const res = await api.request.get(`/api/parts/${partId}`)
-    expect(res.status()).toBe(404)
+      // Verify server-side: the part is gone.
+      const res = await api.request.get(`/api/parts/${partId}`)
+      expect(res.status()).toBe(404)
+    } finally {
+      await api.dispose()
+    }
   })
 })

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared Playwright fixtures.
+ *
+ * Provides authenticated page fixtures so each test starts on a fresh context
+ * already signed in as the desired user. Tests that specifically exercise the
+ * login flow should use the raw `page` fixture and go through the UI.
+ */
+import { test as base, expect } from '@playwright/test'
+import { acquireToken, setAuthCookie, TEST_USERS, type TestUser } from './helpers/auth'
+
+interface Fixtures {
+  /** Sign in as SAMPLE-Sarah (admin) before the test body runs. */
+  adminPage: import('@playwright/test').Page
+  /** Sign in as SAMPLE-Mike (non-admin operator). */
+  operatorPage: import('@playwright/test').Page
+  /** Factory: sign in as any seeded user. */
+  signInAs: (user: TestUser) => Promise<void>
+}
+
+export const test = base.extend<Fixtures>({
+  signInAs: async ({ context, request, baseURL }, use) => {
+    await use(async (user: TestUser) => {
+      if (!baseURL) throw new Error('baseURL not set')
+      const { username, pin } = TEST_USERS[user]
+      const token = await acquireToken(request, username, pin)
+      await setAuthCookie(context, token, baseURL)
+    })
+  },
+
+  adminPage: async ({ context, request, baseURL, page }, use) => {
+    if (!baseURL) throw new Error('baseURL not set')
+    const token = await acquireToken(request, TEST_USERS.admin.username)
+    await setAuthCookie(context, token, baseURL)
+    await use(page)
+  },
+
+  operatorPage: async ({ context, request, baseURL, page }, use) => {
+    if (!baseURL) throw new Error('baseURL not set')
+    const token = await acquireToken(request, TEST_USERS.operator.username)
+    await setAuthCookie(context, token, baseURL)
+    await use(page)
+  },
+})
+
+export { expect }

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,32 @@
+/**
+ * Playwright global setup.
+ *
+ * Resets the e2e test database to a known state before the suite runs:
+ *   1. Delete ./data/test.db (and its WAL/SHM sidecars)
+ *   2. Invoke the seed script which runs migrations + inserts SAMPLE- data
+ *
+ * Runs once per `npx playwright test` invocation (before the webServer starts,
+ * so Nuxt dev opens the freshly-seeded DB).
+ */
+import { execSync } from 'node:child_process'
+import { existsSync, unlinkSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const TEST_DB = resolve(process.cwd(), 'data', 'test.db')
+
+function unlinkIfExists(path: string): void {
+  if (existsSync(path)) unlinkSync(path)
+}
+
+export default async function globalSetup(): Promise<void> {
+  console.log('[e2e] Resetting test DB at', TEST_DB)
+
+  unlinkIfExists(TEST_DB)
+  unlinkIfExists(`${TEST_DB}-wal`)
+  unlinkIfExists(`${TEST_DB}-shm`)
+
+  execSync(`npx tsx server/scripts/seed.ts ${TEST_DB}`, {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  })
+}

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,30 +1,60 @@
 /**
  * Playwright global setup.
  *
- * Resets the e2e test database to a known state before the suite runs:
- *   1. Delete ./data/test.db (and its WAL/SHM sidecars)
- *   2. Invoke the seed script which runs migrations + inserts SAMPLE- data
+ * Resets the e2e test database to a known state before the suite runs.
  *
- * Runs once per `npx playwright test` invocation (before the webServer starts,
- * so Nuxt dev opens the freshly-seeded DB).
+ * IMPORTANT: Playwright starts the webServer *before* running globalSetup,
+ * so the Nuxt dev server already has an open SQLite connection to test.db.
+ * We must NOT delete the file (that would orphan the server's file handle).
+ * Instead we truncate all tables in-place and re-seed, keeping the same
+ * inode so the server's connection stays valid.
  */
 import { execSync } from 'node:child_process'
-import { existsSync, unlinkSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { existsSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import Database from 'better-sqlite3'
 
 const TEST_DB = resolve(process.cwd(), 'data', 'test.db')
-
-function unlinkIfExists(path: string): void {
-  if (existsSync(path)) unlinkSync(path)
-}
 
 export default async function globalSetup(): Promise<void> {
   console.log('[e2e] Resetting test DB at', TEST_DB)
 
-  unlinkIfExists(TEST_DB)
-  unlinkIfExists(`${TEST_DB}-wal`)
-  unlinkIfExists(`${TEST_DB}-shm`)
+  // Ensure the data directory exists (CI fresh checkout).
+  const dir = dirname(TEST_DB)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
 
+  // If the DB already exists (server created it), wipe all user data in-place
+  // so the server's open connection sees the reset immediately.
+  if (existsSync(TEST_DB)) {
+    const db = new Database(TEST_DB)
+    try {
+      db.pragma('journal_mode = WAL')
+      db.pragma('foreign_keys = OFF')
+
+      // Get all user-created tables (skip internal _migrations table and sqlite internals)
+      const tables = db.prepare(`
+        SELECT name FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+          AND name != '_migrations'
+      `).all() as { name: string }[]
+
+      db.transaction(() => {
+        for (const { name } of tables) {
+          db.prepare(`DELETE FROM "${name}"`).run()
+        }
+      })()
+
+      db.pragma('foreign_keys = ON')
+    } finally {
+      db.close()
+    }
+  }
+
+  // Run the seed script which handles migrations + SAMPLE- data insertion.
+  // If the DB didn't exist yet, the seed script creates it from scratch.
   execSync(`npx tsx server/scripts/seed.ts ${TEST_DB}`, {
     stdio: 'inherit',
     cwd: process.cwd(),

--- a/tests/e2e/helpers/api.ts
+++ b/tests/e2e/helpers/api.ts
@@ -7,8 +7,12 @@
  * behavior and makes the suite fast.
  *
  * Usage:
- *   const api = await apiAs(request, baseURL, 'admin')
- *   const { job, path, parts } = await seedJobWithParts(api, { ... })
+ *   const api = await apiAs(baseURL, 'admin')
+ *   try {
+ *     const { job, path, parts } = await seedJobWithParts(api, { ... })
+ *   } finally {
+ *     await api.dispose()
+ *   }
  */
 import { request as pwRequest, type APIRequestContext } from '@playwright/test'
 import { acquireToken, TEST_USERS, type TestUser } from './auth'
@@ -16,6 +20,8 @@ import { acquireToken, TEST_USERS, type TestUser } from './auth'
 export interface ApiClient {
   request: APIRequestContext
   token: string
+  /** Dispose the underlying APIRequestContext to avoid handle leaks. */
+  dispose: () => Promise<void>
 }
 
 /**
@@ -32,7 +38,7 @@ export async function apiAs(baseURL: string, user: TestUser = 'admin'): Promise<
     baseURL,
     extraHTTPHeaders: { Authorization: `Bearer ${token}` },
   })
-  return { request, token }
+  return { request, token, dispose: () => request.dispose() }
 }
 
 // ── Domain helpers ──

--- a/tests/e2e/helpers/api.ts
+++ b/tests/e2e/helpers/api.ts
@@ -1,0 +1,127 @@
+/**
+ * HTTP API helpers for e2e tests.
+ *
+ * We call the API directly (rather than driving the UI) to set up test
+ * preconditions — creating a job, path, or parts for a test that's really
+ * about *advancing* a part, for example. This keeps each test focused on one
+ * behavior and makes the suite fast.
+ *
+ * Usage:
+ *   const api = await apiAs(request, baseURL, 'admin')
+ *   const { job, path, parts } = await seedJobWithParts(api, { ... })
+ */
+import { request as pwRequest, type APIRequestContext } from '@playwright/test'
+import { acquireToken, TEST_USERS, type TestUser } from './auth'
+
+export interface ApiClient {
+  request: APIRequestContext
+  token: string
+}
+
+/**
+ * Create an APIRequestContext with the JWT for the given seeded user baked in.
+ * Use this from tests when you need a request client outside the usual
+ * `request` fixture (e.g. in `beforeEach` where you want admin rights).
+ */
+export async function apiAs(baseURL: string, user: TestUser = 'admin'): Promise<ApiClient> {
+  const bootstrap = await pwRequest.newContext({ baseURL })
+  const token = await acquireToken(bootstrap, TEST_USERS[user].username, TEST_USERS[user].pin)
+  await bootstrap.dispose()
+
+  const request = await pwRequest.newContext({
+    baseURL,
+    extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+  })
+  return { request, token }
+}
+
+// ── Domain helpers ──
+
+export interface StepInput {
+  name: string
+  location?: string
+  assignedTo?: string | null
+  optional?: boolean
+  dependencyType?: 'physical' | 'preferred' | 'completion_gate'
+}
+
+export async function createJob(
+  api: ApiClient,
+  input: { name: string, goalQuantity: number },
+): Promise<{ id: string, name: string }> {
+  const res = await api.request.post('/api/jobs', { data: input })
+  if (!res.ok()) throw new Error(`createJob failed: ${res.status()} ${await res.text()}`)
+  return res.json()
+}
+
+export async function createPath(
+  api: ApiClient,
+  input: {
+    jobId: string
+    name: string
+    goalQuantity: number
+    steps: StepInput[]
+    advancementMode?: 'strict' | 'flexible' | 'per_step'
+  },
+): Promise<{ id: string, name: string, steps: Array<{ id: string, name: string }> }> {
+  const res = await api.request.post('/api/paths', { data: input })
+  if (!res.ok()) throw new Error(`createPath failed: ${res.status()} ${await res.text()}`)
+  return res.json()
+}
+
+export async function createParts(
+  api: ApiClient,
+  input: { jobId: string, pathId: string, quantity: number, certId?: string },
+): Promise<Array<{ id: string }>> {
+  const res = await api.request.post('/api/parts', { data: input })
+  if (!res.ok()) throw new Error(`createParts failed: ${res.status()} ${await res.text()}`)
+  return res.json()
+}
+
+export async function advanceParts(api: ApiClient, partIds: string[]): Promise<void> {
+  const res = await api.request.post('/api/parts/advance', { data: { partIds } })
+  if (!res.ok()) throw new Error(`advanceParts failed: ${res.status()} ${await res.text()}`)
+}
+
+export async function getPath(
+  api: ApiClient,
+  pathId: string,
+): Promise<{ id: string, name: string, steps: Array<{ id: string, name: string, optional?: boolean }> }> {
+  const res = await api.request.get(`/api/paths/${encodeURIComponent(pathId)}`)
+  if (!res.ok()) throw new Error(`getPath failed: ${res.status()}`)
+  return res.json()
+}
+
+export async function getPart(api: ApiClient, partId: string): Promise<{ id: string, currentStepIdx: number, status: string }> {
+  const res = await api.request.get(`/api/parts/${encodeURIComponent(partId)}`)
+  if (!res.ok()) throw new Error(`getPart failed: ${res.status()}`)
+  return res.json()
+}
+
+/**
+ * Create a job + path + N parts in one call. Returned IDs are suitable for
+ * navigating to detail pages.
+ */
+export async function seedJobWithParts(
+  api: ApiClient,
+  opts: {
+    jobName: string
+    pathName?: string
+    partQuantity: number
+    steps?: StepInput[]
+  },
+) {
+  const job = await createJob(api, { name: opts.jobName, goalQuantity: opts.partQuantity })
+  const path = await createPath(api, {
+    jobId: job.id,
+    name: opts.pathName ?? 'Main',
+    goalQuantity: opts.partQuantity,
+    steps: opts.steps ?? [
+      { name: 'CNC Machine' },
+      { name: 'Deburr' },
+      { name: 'Inspection' },
+    ],
+  })
+  const parts = await createParts(api, { jobId: job.id, pathId: path.id, quantity: opts.partQuantity })
+  return { job, path, parts }
+}

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,0 +1,103 @@
+/**
+ * Auth helpers for e2e tests.
+ *
+ * Strategy: authenticate via the HTTP API (fast, deterministic), then plant the
+ * JWT into the `shop-planr-auth-token` cookie. This skips the UI login path in
+ * tests that aren't specifically testing login — keeping them focused on one
+ * behavior each.
+ *
+ * The login UI itself is exercised by tests/e2e/auth.spec.ts.
+ */
+import type { APIRequestContext, BrowserContext } from '@playwright/test'
+
+export const AUTH_COOKIE = 'shop-planr-auth-token'
+export const DEFAULT_PIN = '0000'
+
+export const TEST_USERS = {
+  admin: { username: 'SAMPLE-Sarah', pin: DEFAULT_PIN },
+  operator: { username: 'SAMPLE-Mike', pin: DEFAULT_PIN },
+} as const
+
+/**
+ * SAMPLE-Tony and SAMPLE-Lisa are seeded but intentionally unused by the
+ * fixtures — this lets auth tests exercise the PIN-setup flow against
+ * a known-PIN-less user without racing other tests.
+ */
+export const UNREGISTERED_USERNAME = 'SAMPLE-Tony'
+
+export type TestUser = keyof typeof TEST_USERS
+
+interface PublicUser {
+  id: string
+  username: string
+  displayName: string
+  isAdmin: boolean
+  hasPin: boolean
+}
+
+/**
+ * Token cache — avoids hitting the login rate-limiter (6 / 15s) across a
+ * worker process. Tokens are valid for 24h so reuse is fine for a test run.
+ * Cleared at the start of each playwright invocation because the process is
+ * fresh; cleared within a process via the exported resetAuthCache().
+ */
+const tokenCache = new Map<string, string>()
+
+export function resetAuthCache(): void {
+  tokenCache.clear()
+}
+
+/**
+ * Issue a JWT for the given seeded user. First call sets up the PIN via
+ * /api/auth/setup-pin; subsequent calls hit /api/auth/login (cached after
+ * the first successful login).
+ */
+export async function acquireToken(
+  request: APIRequestContext,
+  username: string,
+  pin: string = DEFAULT_PIN,
+): Promise<string> {
+  const cached = tokenCache.get(username)
+  if (cached) return cached
+
+  const usersRes = await request.get('/api/users')
+  if (!usersRes.ok()) throw new Error(`GET /api/users failed: ${usersRes.status()}`)
+  const users: PublicUser[] = await usersRes.json()
+  const user = users.find(u => u.username === username)
+  if (!user) {
+    throw new Error(`User "${username}" not found. Available: ${users.map(u => u.username).join(', ')}`)
+  }
+
+  const endpoint = user.hasPin ? '/api/auth/login' : '/api/auth/setup-pin'
+  const body = user.hasPin ? { username, pin } : { userId: user.id, pin }
+  const res = await request.post(endpoint, { data: body })
+  if (!res.ok()) {
+    throw new Error(`${endpoint} failed: ${res.status()} ${await res.text()}`)
+  }
+  const { token } = (await res.json()) as { token: string }
+  tokenCache.set(username, token)
+  return token
+}
+
+/**
+ * Plant the JWT cookie onto the browser context so subsequent page loads are
+ * authenticated without going through the UI.
+ */
+export async function setAuthCookie(
+  context: BrowserContext,
+  token: string,
+  baseURL: string,
+): Promise<void> {
+  const url = new URL(baseURL)
+  await context.addCookies([
+    {
+      name: AUTH_COOKIE,
+      value: token,
+      domain: url.hostname,
+      path: '/',
+      httpOnly: false,
+      secure: url.protocol === 'https:',
+      sameSite: 'Lax',
+    },
+  ])
+}

--- a/tests/e2e/jobs.spec.ts
+++ b/tests/e2e/jobs.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Job & path creation e2e.
+ *
+ * Covers the admin-only mutations that drive all downstream workflows:
+ *   1. Create a job with one path + steps from /jobs/new
+ *   2. Add a second path to an existing job from the job detail page
+ *
+ * Editing paths and reordering steps are covered by integration tests.
+ */
+import { test, expect } from './fixtures'
+import { apiAs, createJob } from './helpers/api'
+
+test.describe('jobs', () => {
+  test('admin creates a job with a path from /jobs/new', async ({ adminPage }) => {
+    const jobName = `E2E Job ${Date.now()}`
+
+    await adminPage.goto('/jobs/new')
+    await expect(adminPage.getByRole('heading', { name: 'New Job' })).toBeVisible()
+    await adminPage.waitForLoadState('networkidle')
+
+    await adminPage.getByTestId('job-name-input').fill(jobName)
+    await adminPage.getByTestId('job-goal-qty-input').fill('7')
+
+    await adminPage.getByRole('button', { name: 'Add Path' }).click()
+    // Wait for the new path row to render — the form uses `v-for` over
+    // pathDrafts so the input appears only after the click takes effect.
+    await expect(adminPage.getByTestId('path-name-input-0')).toBeVisible()
+    await adminPage.getByTestId('path-name-input-0').fill('Main Route')
+
+    // ProcessLocationDropdown binds the typed text via v-model, so we can
+    // just type a process name and dismiss the suggestion overlay.
+    const processInput = adminPage.getByTestId('process-location-input-process').first()
+    await processInput.fill('CNC Machine')
+    await adminPage.keyboard.press('Escape')
+
+    await adminPage.getByTestId('job-submit-btn').click()
+
+    await expect(adminPage).toHaveURL(/\/jobs\/job_/, { timeout: 10_000 })
+    await expect(adminPage.getByRole('heading', { name: jobName })).toBeVisible()
+  })
+
+  test('admin adds a second path to an existing job', async ({ adminPage, baseURL }) => {
+    // Use the API for setup — we're testing the add-path flow, not creation.
+    const api = await apiAs(baseURL!, 'admin')
+    const job = await createJob(api, { name: `E2E Multipath ${Date.now()}`, goalQuantity: 10 })
+
+    await adminPage.goto(`/jobs/${job.id}`)
+    await expect(adminPage.getByRole('heading', { name: job.name })).toBeVisible()
+
+    // Open the "New Path" editor.
+    await adminPage.getByRole('button', { name: 'Add Path' }).click()
+
+    // Fill the new-path form. The UInput with placeholder "e.g. Standard Route"
+    // is the path name; we rely on placeholder text since this editor is
+    // lightweight and lives on the job detail page (not in JobCreationForm).
+    await adminPage.getByPlaceholder('e.g. Standard Route').fill('Expedited')
+
+    const processInput = adminPage.getByTestId('process-location-input-process').first()
+    await processInput.fill('Inspection')
+    await adminPage.keyboard.press('Escape')
+
+    await adminPage.getByRole('button', { name: 'Create Path', exact: true }).click()
+
+    // The new path now appears in the paths list on the job page.
+    await expect(adminPage.getByText('Expedited')).toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/tests/e2e/jobs.spec.ts
+++ b/tests/e2e/jobs.spec.ts
@@ -42,26 +42,30 @@ test.describe('jobs', () => {
   test('admin adds a second path to an existing job', async ({ adminPage, baseURL }) => {
     // Use the API for setup — we're testing the add-path flow, not creation.
     const api = await apiAs(baseURL!, 'admin')
-    const job = await createJob(api, { name: `E2E Multipath ${Date.now()}`, goalQuantity: 10 })
+    try {
+      const job = await createJob(api, { name: `E2E Multipath ${Date.now()}`, goalQuantity: 10 })
 
-    await adminPage.goto(`/jobs/${job.id}`)
-    await expect(adminPage.getByRole('heading', { name: job.name })).toBeVisible()
+      await adminPage.goto(`/jobs/${job.id}`)
+      await expect(adminPage.getByRole('heading', { name: job.name })).toBeVisible()
 
-    // Open the "New Path" editor.
-    await adminPage.getByRole('button', { name: 'Add Path' }).click()
+      // Open the "New Path" editor.
+      await adminPage.getByRole('button', { name: 'Add Path' }).click()
 
-    // Fill the new-path form. The UInput with placeholder "e.g. Standard Route"
-    // is the path name; we rely on placeholder text since this editor is
-    // lightweight and lives on the job detail page (not in JobCreationForm).
-    await adminPage.getByPlaceholder('e.g. Standard Route').fill('Expedited')
+      // Fill the new-path form. The UInput with placeholder "e.g. Standard Route"
+      // is the path name; we rely on placeholder text since this editor is
+      // lightweight and lives on the job detail page (not in JobCreationForm).
+      await adminPage.getByPlaceholder('e.g. Standard Route').fill('Expedited')
 
-    const processInput = adminPage.getByTestId('process-location-input-process').first()
-    await processInput.fill('Inspection')
-    await adminPage.keyboard.press('Escape')
+      const processInput = adminPage.getByTestId('process-location-input-process').first()
+      await processInput.fill('Inspection')
+      await adminPage.keyboard.press('Escape')
 
-    await adminPage.getByRole('button', { name: 'Create Path', exact: true }).click()
+      await adminPage.getByRole('button', { name: 'Create Path', exact: true }).click()
 
-    // The new path now appears in the paths list on the job page.
-    await expect(adminPage.getByText('Expedited')).toBeVisible({ timeout: 10_000 })
+      // The new path now appears in the paths list on the job page.
+      await expect(adminPage.getByText('Expedited')).toBeVisible({ timeout: 10_000 })
+    } finally {
+      await api.dispose()
+    }
   })
 })

--- a/tests/e2e/parts.spec.ts
+++ b/tests/e2e/parts.spec.ts
@@ -15,96 +15,108 @@ import { apiAs, createJob, createPath, createParts, advanceParts, getPath } from
 test.describe('parts lifecycle', () => {
   test('admin creates parts on the first step via PartCreationPanel', async ({ adminPage, baseURL }) => {
     const api = await apiAs(baseURL!, 'admin')
-    const job = await createJob(api, { name: `E2E Create-Parts ${Date.now()}`, goalQuantity: 5 })
-    const path = await createPath(api, {
-      jobId: job.id,
-      name: 'Main',
-      goalQuantity: 5,
-      steps: [{ name: 'CNC Machine' }, { name: 'Inspection' }],
-    })
+    try {
+      const job = await createJob(api, { name: `E2E Create-Parts ${Date.now()}`, goalQuantity: 5 })
+      const path = await createPath(api, {
+        jobId: job.id,
+        name: 'Main',
+        goalQuantity: 5,
+        steps: [{ name: 'CNC Machine' }, { name: 'Inspection' }],
+      })
 
-    await adminPage.goto(`/parts/step/${path.steps[0]!.id}`)
-    // useStepView fetches step data on mount; dev-server page loads are slow
-    // in CI-like conditions — give the heading 20s and then settle on idle.
-    await expect(adminPage.getByRole('heading', { name: 'CNC Machine' })).toBeVisible({ timeout: 20_000 })
-    await adminPage.waitForLoadState('networkidle')
+      await adminPage.goto(`/parts/step/${path.steps[0]!.id}`)
+      // useStepView fetches step data on mount; dev-server page loads are slow
+      // in CI-like conditions — give the heading 20s and then settle on idle.
+      await expect(adminPage.getByRole('heading', { name: 'CNC Machine' })).toBeVisible({ timeout: 20_000 })
+      await adminPage.waitForLoadState('networkidle')
 
-    const qtyInput = adminPage.locator('input[type="number"]').first()
-    await qtyInput.fill('3')
+      const qtyInput = adminPage.locator('input[type="number"]').first()
+      await qtyInput.fill('3')
 
-    await adminPage.getByRole('button', { name: 'Create', exact: true }).click()
+      await adminPage.getByRole('button', { name: 'Create', exact: true }).click()
 
-    await expect(adminPage.getByText(/3 parts created/i).first()).toBeVisible({ timeout: 10_000 })
+      await expect(adminPage.getByText(/3 parts created/i).first()).toBeVisible({ timeout: 10_000 })
+    } finally {
+      await api.dispose()
+    }
   })
 
   test('operator advances parts from one step to the next', async ({ operatorPage, baseURL }) => {
     // Setup: job with 2 parts already sitting on step 2 (Deburr).
     const api = await apiAs(baseURL!, 'admin')
-    const job = await createJob(api, { name: `E2E Advance ${Date.now()}`, goalQuantity: 2 })
-    const path = await createPath(api, {
-      jobId: job.id,
-      name: 'Main',
-      goalQuantity: 2,
-      steps: [{ name: 'CNC Machine' }, { name: 'Deburr' }, { name: 'Inspection' }],
-    })
-    const parts = await createParts(api, { jobId: job.id, pathId: path.id, quantity: 2 })
-    // Advance them past CNC so they land on Deburr (step 1).
-    await advanceParts(api, parts.map(p => p.id))
+    try {
+      const job = await createJob(api, { name: `E2E Advance ${Date.now()}`, goalQuantity: 2 })
+      const path = await createPath(api, {
+        jobId: job.id,
+        name: 'Main',
+        goalQuantity: 2,
+        steps: [{ name: 'CNC Machine' }, { name: 'Deburr' }, { name: 'Inspection' }],
+      })
+      const parts = await createParts(api, { jobId: job.id, pathId: path.id, quantity: 2 })
+      // Advance them past CNC so they land on Deburr (step 1).
+      await advanceParts(api, parts.map(p => p.id))
 
-    await operatorPage.goto(`/parts/step/${path.steps[1]!.id}`)
-    await expect(operatorPage.getByRole('heading', { name: 'Deburr' })).toBeVisible({ timeout: 10_000 })
-    await operatorPage.waitForLoadState('networkidle')
+      await operatorPage.goto(`/parts/step/${path.steps[1]!.id}`)
+      await expect(operatorPage.getByRole('heading', { name: 'Deburr' })).toBeVisible({ timeout: 10_000 })
+      await operatorPage.waitForLoadState('networkidle')
 
-    const advanceBtn = operatorPage.getByRole('button', { name: 'Advance', exact: true })
-    await expect(advanceBtn).toBeEnabled()
-    await advanceBtn.click()
+      const advanceBtn = operatorPage.getByRole('button', { name: 'Advance', exact: true })
+      await expect(advanceBtn).toBeEnabled()
+      await advanceBtn.click()
 
-    // Nuxt UI toast renders the same text in several nodes (title, description,
-    // sr-only alert region) — `.first()` sidesteps strict-mode violations.
-    await expect(operatorPage.getByText(/2 parts moved to Inspection/i).first()).toBeVisible({ timeout: 10_000 })
+      // Nuxt UI toast renders the same text in several nodes (title, description,
+      // sr-only alert region) — `.first()` sidesteps strict-mode violations.
+      await expect(operatorPage.getByText(/2 parts moved to Inspection/i).first()).toBeVisible({ timeout: 10_000 })
+    } finally {
+      await api.dispose()
+    }
   })
 
   test('admin skips an optional step via Advanced options', async ({ adminPage, baseURL }) => {
     // Setup: path where step 2 is optional. Create 1 part, advance it to
     // step 2, then skip ahead to step 3.
     const api = await apiAs(baseURL!, 'admin')
-    const job = await createJob(api, { name: `E2E Skip ${Date.now()}`, goalQuantity: 1 })
-    const path = await createPath(api, {
-      jobId: job.id,
-      name: 'Main',
-      goalQuantity: 1,
-      advancementMode: 'flexible',
-      steps: [
-        { name: 'CNC Machine' },
-        { name: 'Optional Inspection', optional: true },
-        { name: 'Final Inspection' },
-      ],
-    })
-    const [part] = await createParts(api, { jobId: job.id, pathId: path.id, quantity: 1 })
-    await advanceParts(api, [part!.id])
-    // Part is now at step 1 (Optional Inspection).
+    try {
+      const job = await createJob(api, { name: `E2E Skip ${Date.now()}`, goalQuantity: 1 })
+      const path = await createPath(api, {
+        jobId: job.id,
+        name: 'Main',
+        goalQuantity: 1,
+        advancementMode: 'flexible',
+        steps: [
+          { name: 'CNC Machine' },
+          { name: 'Optional Inspection', optional: true },
+          { name: 'Final Inspection' },
+        ],
+      })
+      const [part] = await createParts(api, { jobId: job.id, pathId: path.id, quantity: 1 })
+      await advanceParts(api, [part!.id])
+      // Part is now at step 1 (Optional Inspection).
 
-    const fresh = await getPath(api, path.id)
-    const targetStepId = fresh.steps.find(s => s.name === 'Final Inspection')!.id
+      const fresh = await getPath(api, path.id)
+      const targetStepId = fresh.steps.find(s => s.name === 'Final Inspection')!.id
 
-    await adminPage.goto(`/parts/step/${fresh.steps[1]!.id}`)
-    await expect(adminPage.getByRole('heading', { name: 'Optional Inspection' })).toBeVisible({ timeout: 10_000 })
-    await adminPage.waitForLoadState('networkidle')
+      await adminPage.goto(`/parts/step/${fresh.steps[1]!.id}`)
+      await expect(adminPage.getByRole('heading', { name: 'Optional Inspection' })).toBeVisible({ timeout: 10_000 })
+      await adminPage.waitForLoadState('networkidle')
 
-    // Expand Advanced options (admin-only section in ProcessAdvancementPanel).
-    await adminPage.getByRole('button', { name: /advanced options/i }).click()
+      // Expand Advanced options (admin-only section in ProcessAdvancementPanel).
+      await adminPage.getByRole('button', { name: /advanced options/i }).click()
 
-    // Pick the skip-to target from the dropdown. USelect renders a native-ish
-    // picker — pass the target option's visible label.
-    await adminPage.locator('button[role="combobox"]').first().click()
-    await adminPage.getByRole('option', { name: /Final Inspection/ }).click()
+      // Pick the skip-to target from the dropdown. USelect renders a native-ish
+      // picker — pass the target option's visible label.
+      await adminPage.locator('button[role="combobox"]').first().click()
+      await adminPage.getByRole('option', { name: /Final Inspection/ }).click()
 
-    await adminPage.getByRole('button', { name: /skip selected parts/i }).click()
+      await adminPage.getByRole('button', { name: /skip selected parts/i }).click()
 
-    await expect(adminPage.getByText('Parts skipped', { exact: true }).first()).toBeVisible({ timeout: 10_000 })
+      await expect(adminPage.getByText('Parts skipped', { exact: true }).first()).toBeVisible({ timeout: 10_000 })
 
-    // Verify server-side: the part has moved to the target step (Final Inspection).
-    const updated = await (await api.request.get(`/api/parts/${part!.id}`)).json()
-    expect(updated.currentStepId).toBe(targetStepId)
+      // Verify server-side: the part has moved to the target step (Final Inspection).
+      const updated = await (await api.request.get(`/api/parts/${part!.id}`)).json()
+      expect(updated.currentStepId).toBe(targetStepId)
+    } finally {
+      await api.dispose()
+    }
   })
 })

--- a/tests/e2e/parts.spec.ts
+++ b/tests/e2e/parts.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Parts lifecycle e2e.
+ *
+ * Covers the operator-facing flows that move parts through the shop:
+ *   1. Create parts on the first step of a path
+ *   2. Advance parts from one step to the next via the step view
+ *   3. Skip an optional step
+ *
+ * Preconditions are set up via the API (createJob, createPath) so each test
+ * starts with a clean fixture independent of the other tests.
+ */
+import { test, expect } from './fixtures'
+import { apiAs, createJob, createPath, createParts, advanceParts, getPath } from './helpers/api'
+
+test.describe('parts lifecycle', () => {
+  test('admin creates parts on the first step via PartCreationPanel', async ({ adminPage, baseURL }) => {
+    const api = await apiAs(baseURL!, 'admin')
+    const job = await createJob(api, { name: `E2E Create-Parts ${Date.now()}`, goalQuantity: 5 })
+    const path = await createPath(api, {
+      jobId: job.id,
+      name: 'Main',
+      goalQuantity: 5,
+      steps: [{ name: 'CNC Machine' }, { name: 'Inspection' }],
+    })
+
+    await adminPage.goto(`/parts/step/${path.steps[0]!.id}`)
+    // useStepView fetches step data on mount; dev-server page loads are slow
+    // in CI-like conditions — give the heading 20s and then settle on idle.
+    await expect(adminPage.getByRole('heading', { name: 'CNC Machine' })).toBeVisible({ timeout: 20_000 })
+    await adminPage.waitForLoadState('networkidle')
+
+    const qtyInput = adminPage.locator('input[type="number"]').first()
+    await qtyInput.fill('3')
+
+    await adminPage.getByRole('button', { name: 'Create', exact: true }).click()
+
+    await expect(adminPage.getByText(/3 parts created/i).first()).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('operator advances parts from one step to the next', async ({ operatorPage, baseURL }) => {
+    // Setup: job with 2 parts already sitting on step 2 (Deburr).
+    const api = await apiAs(baseURL!, 'admin')
+    const job = await createJob(api, { name: `E2E Advance ${Date.now()}`, goalQuantity: 2 })
+    const path = await createPath(api, {
+      jobId: job.id,
+      name: 'Main',
+      goalQuantity: 2,
+      steps: [{ name: 'CNC Machine' }, { name: 'Deburr' }, { name: 'Inspection' }],
+    })
+    const parts = await createParts(api, { jobId: job.id, pathId: path.id, quantity: 2 })
+    // Advance them past CNC so they land on Deburr (step 1).
+    await advanceParts(api, parts.map(p => p.id))
+
+    await operatorPage.goto(`/parts/step/${path.steps[1]!.id}`)
+    await expect(operatorPage.getByRole('heading', { name: 'Deburr' })).toBeVisible({ timeout: 10_000 })
+    await operatorPage.waitForLoadState('networkidle')
+
+    const advanceBtn = operatorPage.getByRole('button', { name: 'Advance', exact: true })
+    await expect(advanceBtn).toBeEnabled()
+    await advanceBtn.click()
+
+    // Nuxt UI toast renders the same text in several nodes (title, description,
+    // sr-only alert region) — `.first()` sidesteps strict-mode violations.
+    await expect(operatorPage.getByText(/2 parts moved to Inspection/i).first()).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('admin skips an optional step via Advanced options', async ({ adminPage, baseURL }) => {
+    // Setup: path where step 2 is optional. Create 1 part, advance it to
+    // step 2, then skip ahead to step 3.
+    const api = await apiAs(baseURL!, 'admin')
+    const job = await createJob(api, { name: `E2E Skip ${Date.now()}`, goalQuantity: 1 })
+    const path = await createPath(api, {
+      jobId: job.id,
+      name: 'Main',
+      goalQuantity: 1,
+      advancementMode: 'flexible',
+      steps: [
+        { name: 'CNC Machine' },
+        { name: 'Optional Inspection', optional: true },
+        { name: 'Final Inspection' },
+      ],
+    })
+    const [part] = await createParts(api, { jobId: job.id, pathId: path.id, quantity: 1 })
+    await advanceParts(api, [part!.id])
+    // Part is now at step 1 (Optional Inspection).
+
+    const fresh = await getPath(api, path.id)
+    const targetStepId = fresh.steps.find(s => s.name === 'Final Inspection')!.id
+
+    await adminPage.goto(`/parts/step/${fresh.steps[1]!.id}`)
+    await expect(adminPage.getByRole('heading', { name: 'Optional Inspection' })).toBeVisible({ timeout: 10_000 })
+    await adminPage.waitForLoadState('networkidle')
+
+    // Expand Advanced options (admin-only section in ProcessAdvancementPanel).
+    await adminPage.getByRole('button', { name: /advanced options/i }).click()
+
+    // Pick the skip-to target from the dropdown. USelect renders a native-ish
+    // picker — pass the target option's visible label.
+    await adminPage.locator('button[role="combobox"]').first().click()
+    await adminPage.getByRole('option', { name: /Final Inspection/ }).click()
+
+    await adminPage.getByRole('button', { name: /skip selected parts/i }).click()
+
+    await expect(adminPage.getByText('Parts skipped', { exact: true }).first()).toBeVisible({ timeout: 10_000 })
+
+    // Verify server-side: the part has moved to the target step (Final Inspection).
+    const updated = await (await api.request.get(`/api/parts/${part!.id}`)).json()
+    expect(updated.currentStepId).toBe(targetStepId)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
     environment: 'happy-dom',
     globals: true,
     pool: 'threads',
+    // Exclude Playwright e2e specs — they use a different runner and import
+    // `@playwright/test`, which refuses to load under vitest. Run with
+    // `npm run test:e2e` instead.
+    exclude: ['**/node_modules/**', 'tests/e2e/**'],
     env: {
       TZ: 'UTC',
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, configDefaults } from 'vitest/config'
 import { resolve } from 'path'
 import type { Plugin } from 'vite'
 
@@ -31,7 +31,7 @@ export default defineConfig({
     // Exclude Playwright e2e specs — they use a different runner and import
     // `@playwright/test`, which refuses to load under vitest. Run with
     // `npm run test:e2e` instead.
-    exclude: ['**/node_modules/**', 'tests/e2e/**'],
+    exclude: [...configDefaults.exclude, 'tests/e2e/**'],
     env: {
       TZ: 'UTC',
     },


### PR DESCRIPTION
Covers the flows whose regressions would take the product offline: auth
(PIN setup, login, switch user, log out), job/path creation, parts
lifecycle (create/advance/skip), admin-only deletion with cascade, and
access-control gates for non-admin users.

- 15 tests across 5 spec files, all passing in ~2min
- Dedicated test DB (./data/test.db) reset + reseeded before each run
- Shared fixtures for authenticated admin/operator pages
- Opt-in CI workflow: runs on `run-e2e` PR label or workflow_dispatch
- Token cache in auth helper + env-gated rate-limit bypass for test runs
- TESTING.md documents standards and scope boundaries for all test layers

https://claude.ai/code/session_01QCJjVGFroPhoTuiBtHpD3y