### PR TITLE
chore: add Zod request body validation to 17 remaining API routes

### DIFF
--- a/.ai/architecture.md
+++ b/.ai/architecture.md
@@ -83,6 +83,7 @@ Do NOT use `defineEventHandler` with manual try/catch blocks. Do NOT use inline 
 - Repository enforcing "serial must advance sequentially" → move to service
 - API route calling `repos.jobs.create()` directly → call service instead
 - API route using `readBody()` without Zod schema → add `parseBody(event, schema)`
+- Schema file declaring `z.string().min(1)` for an ID or `z.number().int().positive()` for a quantity → import from `server/schemas/_primitives.ts` instead
 
 ## Key Files (Planned)
 
@@ -94,6 +95,7 @@ Do NOT use `defineEventHandler` with manual try/catch blocks. Do NOT use inline 
 | `server/utils/httpError.ts` | `defineApiHandler`, `httpError`, `STATUS_MESSAGES`, `ERROR_STATUS_MAP` |
 | `server/utils/idGenerator.ts` | `generateId(prefix)` + sequential SN counter |
 | `server/utils/validation.ts` | `parseBody()` — Zod schema validation for request bodies |
+| `server/schemas/_primitives.ts` | Shared Zod building blocks (`requiredId`, `positiveInt`, domain enums, batch ID arrays, `pinSchema`) — imported by all domain schema files |
 | `server/repositories/factory.ts` | Returns `RepositorySet` based on config |
 | `server/repositories/sqlite/index.ts` | DB init, WAL mode, migration runner |
 | `server/services/authService.ts` | PIN hashing, JWT sign/verify (ES256), key pair management, token refresh |

--- a/.ai/architecture.md
+++ b/.ai/architecture.md
@@ -95,7 +95,7 @@ Do NOT use `defineEventHandler` with manual try/catch blocks. Do NOT use inline 
 | `server/utils/httpError.ts` | `defineApiHandler`, `httpError`, `STATUS_MESSAGES`, `ERROR_STATUS_MAP` |
 | `server/utils/idGenerator.ts` | `generateId(prefix)` + sequential SN counter |
 | `server/utils/validation.ts` | `parseBody()` — Zod schema validation for request bodies |
-| `server/schemas/_primitives.ts` | Shared Zod building blocks (`requiredId`, `positiveInt`, domain enums, batch ID arrays, `pinSchema`) — imported by all domain schema files |
+| `server/schemas/_primitives.ts` | Shared Zod building blocks (`requiredId`, `positiveInt`, `pinSchema`) + domain enum schemas derived from `as const` arrays in `domain.ts` — imported by all domain schema files |
 | `server/repositories/factory.ts` | Returns `RepositorySet` based on config |
 | `server/repositories/sqlite/index.ts` | DB init, WAL mode, migration runner |
 | `server/services/authService.ts` | PIN hashing, JWT sign/verify (ES256), key pair management, token refresh |

--- a/.kiro/steering/coding-standards.md
+++ b/.kiro/steering/coding-standards.md
@@ -94,6 +94,44 @@ API routes that accept request bodies MUST validate them with Zod schemas using 
 
 Schemas live in `server/schemas/` and are colocated by domain (e.g., `pathSchemas.ts`, `jobSchemas.ts`). Each route imports its schema and calls `parseBody(event, schema)` instead of raw `readBody(event)`.
 
+### Shared Primitives (`server/schemas/_primitives.ts`)
+
+Common field patterns are centralized in `_primitives.ts` to avoid duplication across schema files. When writing a new schema, import from `_primitives` instead of re-declaring the same patterns:
+
+| Primitive | Type | Use for |
+|---|---|---|
+| `requiredId` | `z.string().min(1)` | Any required entity ID field (jobId, pathId, stepId, certId, etc.) |
+| `positiveInt` | `z.number().int().positive()` | goalQuantity, requiredQuantity, priority |
+| `dependencyTypeEnum` | `z.enum([...])` | Step dependency type (physical/preferred/completion_gate) |
+| `advancementModeEnum` | `z.enum([...])` | Path advancement mode (strict/flexible/per_step) |
+| `scrapReasonEnum` | `z.enum([...])` | Scrap reason values |
+| `certTypeEnum` | `z.enum([...])` | Certificate type (material/process) |
+| `batchIds100` | `z.array(requiredId).min(1).max(100)` | Standard batch operations (advance, overrides) |
+| `batchIds500` | `z.array(requiredId).min(1).max(500)` | Larger read-only batch fetches (step statuses) |
+| `pinSchema` | `z.string().regex(/^\d{4}$/)` | 4-digit PIN |
+
+When adding a new primitive, add it to `_primitives.ts` with a descriptive name and JSDoc comment. Never scatter raw `z.string().min(1)` for ID fields or `z.number().int().positive()` for quantities across schema files — use the shared primitive.
+
+```ts
+// CORRECT — use shared primitives
+import { requiredId, positiveInt } from './_primitives'
+
+export const mySchema = z.object({
+  jobId: requiredId,
+  quantity: positiveInt,
+})
+```
+
+```ts
+// WRONG — re-declares patterns that already exist in _primitives
+export const mySchema = z.object({
+  jobId: z.string().min(1, 'jobId is required'),
+  quantity: z.number().int().positive('quantity must be positive'),
+})
+```
+
+### Route Pattern
+
 ```ts
 // CORRECT — validated input, wrong types → 400
 import { createPathSchema } from '../../schemas/pathSchemas'

--- a/.kiro/steering/coding-standards.md
+++ b/.kiro/steering/coding-standards.md
@@ -102,13 +102,13 @@ Common field patterns are centralized in `_primitives.ts` to avoid duplication a
 |---|---|---|
 | `requiredId` | `z.string().min(1)` | Any required entity ID field (jobId, pathId, stepId, certId, etc.) |
 | `positiveInt` | `z.number().int().positive()` | goalQuantity, requiredQuantity, priority |
-| `dependencyTypeEnum` | `z.enum([...])` | Step dependency type (physical/preferred/completion_gate) |
-| `advancementModeEnum` | `z.enum([...])` | Path advancement mode (strict/flexible/per_step) |
-| `scrapReasonEnum` | `z.enum([...])` | Scrap reason values |
-| `certTypeEnum` | `z.enum([...])` | Certificate type (material/process) |
-| `batchIds100` | `z.array(requiredId).min(1).max(100)` | Standard batch operations (advance, overrides) |
-| `batchIds500` | `z.array(requiredId).min(1).max(500)` | Larger read-only batch fetches (step statuses) |
+| `dependencyTypeEnum` | `z.enum(DEPENDENCY_TYPES)` | Step dependency type — derived from `domain.ts` |
+| `advancementModeEnum` | `z.enum(ADVANCEMENT_MODES)` | Path advancement mode — derived from `domain.ts` |
+| `scrapReasonEnum` | `z.enum(SCRAP_REASONS)` | Scrap reason values — derived from `domain.ts` |
+| `certTypeEnum` | `z.enum(CERT_TYPES)` | Certificate type — derived from `domain.ts` |
 | `pinSchema` | `z.string().regex(/^\d{4}$/)` | 4-digit PIN |
+
+Domain enums (`dependencyTypeEnum`, `advancementModeEnum`, `scrapReasonEnum`, `certTypeEnum`) are derived from `as const` arrays exported by `server/types/domain.ts`. Adding a new enum variant to the array in `domain.ts` automatically updates both the TypeScript union type and the Zod schema — no second file to remember.
 
 When adding a new primitive, add it to `_primitives.ts` with a descriptive name and JSDoc comment. Never scatter raw `z.string().min(1)` for ID fields or `z.number().int().positive()` for quantities across schema files — use the shared primitive.
 

--- a/.kiro/steering/test-execution.md
+++ b/.kiro/steering/test-execution.md
@@ -5,6 +5,19 @@ description: "How to run tests and read output without re-running or losing data
 
 # Test Execution Rules
 
+## MANDATORY — Read This First
+
+You MUST use the EXACT commands in this file when running tests. Copy-paste them. Do NOT:
+
+- Invent your own grep pattern (e.g., `grep -E "^( Test Files| Tests  )"` — WRONG, anchored `^` breaks on vitest output)
+- Use `npm run test` or `npm test` instead of `npx vitest run`
+- Omit the `2>&1` redirect (stderr contains test output)
+- Change `head -200` to a different limit
+- Add `--reporter=verbose` on full-suite or folder runs
+- Pipe through `tail` instead of the canonical grep for multi-file runs
+
+If you deviate from these commands, you WILL get incomplete or misleading output and waste time re-running. The patterns below have been tested against real output from this project. Trust them.
+
 ## The Problem
 
 Vitest output includes noisy migration lines (`Migration N: ... — applied`) repeated per test file, plus verbose per-test lines. Naive `grep` or `tail` misses failures, and the AI ends up re-running the full suite 3-4 times trying different filters. Stop that.
@@ -94,3 +107,4 @@ Do NOT re-run the entire suite or folder to check if one file is fixed. Run the 
 4. Do not use `--reporter=verbose` on folder-level or full-suite runs — it makes the output enormous. Only use it on single files when debugging a failure.
 5. The `head -200` cap prevents runaway output. If you're hitting it, you have too many failures — focus on one file at a time.
 6. Property tests use `fast-check` and can be slow (5-10s each). Set `timeout: 120000` on the vitest run if you're seeing timeout failures on property tests.
+7. These commands are NOT suggestions. They are the ONLY way to run tests in this project. If you think you have a better grep pattern — you don't. Use the ones above.

--- a/AI-MAP.md
+++ b/AI-MAP.md
@@ -73,7 +73,20 @@ server/
     workQueueHelpers.ts  → findFirstActiveStep(), shouldIncludeStep() — first-step visibility logic for work queue entry assembly
     services.ts          → getServices() singleton — wires all 12 services together
     pageToggles.ts       → DEFAULT_PAGE_TOGGLES, ROUTE_TOGGLE_MAP, ALWAYS_ENABLED_ROUTES, mergePageToggles(), isPageEnabled() — auto-imported by Nitro
-  schemas/               → Zod request body schemas by domain (pathSchemas.ts, operatorSchemas.ts, etc.)
+  schemas/
+    _primitives.ts       → Shared Zod building blocks (requiredId, positiveInt, dependencyTypeEnum, advancementModeEnum, scrapReasonEnum, certTypeEnum, batchIds100/500, pinSchema) — imported by all domain schema files
+    authSchemas.ts       → Login, PIN setup/reset, token refresh
+    bomSchemas.ts        → BOM create/update/edit, list query
+    certSchemas.ts       → Certificate create, batch-attach
+    jiraSchemas.ts       → Jira push/link/comment
+    jobSchemas.ts        → Job create/update, priority bulk-update
+    operatorSchemas.ts   → Work queue query (groupBy)
+    partSchemas.ts       → Part create, scrap, force-complete, advance-to, overrides, attach-cert, waive-step, batch advance/statuses
+    pathSchemas.ts       → Path create/update, step config, advancement mode, batch distributions, batch path operations
+    settingsSchemas.ts   → Settings update (Jira connection, field mappings, page toggles)
+    tagSchemas.ts        → Tag create/update, job tags, delete query
+    templateSchemas.ts   → Template create/update, apply
+    userSchemas.ts       → User create/update
   types/
     domain.ts            → 26+ domain types (Job, Path, ProcessStep, SerialNumber, SnStepStatus, SnStepOverride, BomVersion, ProcessLibraryEntry, LocationLibraryEntry, etc.)
     api.ts               → 25+ API input types (ScrapSerialInput, ForceCompleteInput, AdvanceToStepInput, EditBomInput, etc.)

--- a/AI-MAP.md
+++ b/AI-MAP.md
@@ -74,7 +74,7 @@ server/
     services.ts          → getServices() singleton — wires all 12 services together
     pageToggles.ts       → DEFAULT_PAGE_TOGGLES, ROUTE_TOGGLE_MAP, ALWAYS_ENABLED_ROUTES, mergePageToggles(), isPageEnabled() — auto-imported by Nitro
   schemas/
-    _primitives.ts       → Shared Zod building blocks (requiredId, positiveInt, dependencyTypeEnum, advancementModeEnum, scrapReasonEnum, certTypeEnum, batchIds100/500, pinSchema) — imported by all domain schema files
+    _primitives.ts       → Shared Zod building blocks (requiredId, positiveInt, pinSchema) + domain enum schemas (dependencyTypeEnum, advancementModeEnum, scrapReasonEnum, certTypeEnum) derived from `as const` arrays in `server/types/domain.ts` — imported by all domain schema files
     authSchemas.ts       → Login, PIN setup/reset, token refresh
     bomSchemas.ts        → BOM create/update/edit, list query
     certSchemas.ts       → Certificate create, batch-attach

--- a/app/composables/useCerts.ts
+++ b/app/composables/useCerts.ts
@@ -1,6 +1,6 @@
 import { ref, readonly } from 'vue'
 import type { Certificate } from '~/types/domain'
-import type { CreateCertInput, BatchAttachCertInput } from '~/types/api'
+import type { CreateCertInput } from '~/types/api'
 
 const certs = ref<Certificate[]>([])
 const loading = ref(false)
@@ -35,7 +35,7 @@ export function useCerts() {
     return await $api<Certificate>(`/api/certs/${id}`)
   }
 
-  async function batchAttachCert(input: BatchAttachCertInput): Promise<void> {
+  async function batchAttachCert(input: { certId: string, partIds: string[] }): Promise<void> {
     await $api('/api/certs/batch-attach', {
       method: 'POST',
       body: input,

--- a/app/pages/certs.vue
+++ b/app/pages/certs.vue
@@ -2,7 +2,6 @@
 import type { Certificate } from '~/types/domain'
 
 const { certs, loading, fetchCerts, createCert, batchAttachCert } = useCerts()
-const { authenticatedUser } = useAuth()
 
 // UI state
 const showForm = ref(false)
@@ -74,19 +73,11 @@ async function onBatchAttach() {
     return
   }
 
-  if (!authenticatedUser.value) {
-    batchError.value = 'Please select a user first'
-    return
-  }
-
-  const userId = authenticatedUser.value.id
-
   batchSaving.value = true
   try {
     await batchAttachCert({
       certId: batchCertId.value,
       partIds: ids,
-      userId,
     })
     batchSuccess.value = `Attached certificate to ${ids.length} part(s)`
     batchPartIds.value = ''

--- a/server/api/certs/batch-attach.post.ts
+++ b/server/api/certs/batch-attach.post.ts
@@ -3,7 +3,7 @@ import { batchAttachCertSchema } from '../../schemas/certSchemas'
 defineRouteMeta({
   openAPI: {
     tags: ['Certificates'],
-    description: 'Batch-attach a certificate to multiple parts.',
+    description: 'Batch-attach a certificate to multiple parts at their current step.',
     requestBody: zodRequestBody(batchAttachCertSchema),
     responses: {
       200: { description: 'Certificate attached to parts' },
@@ -15,6 +15,24 @@ defineRouteMeta({
 export default defineApiHandler(async (event) => {
   const body = await parseBody(event, batchAttachCertSchema)
   const userId = getAuthUserId(event)
-  const { certService } = getServices()
-  return certService.batchAttachCert({ ...body, userId })
+  const { partService, pathService, certService } = getServices()
+
+  // Resolve each part's current step (same pattern as single attach-cert route)
+  const attachments = body.partIds.map((partId) => {
+    const part = partService.getPart(partId)
+    const path = pathService.getPath(part.pathId)
+    const step = part.currentStepId !== null
+      ? path.steps.find(s => s.id === part.currentStepId)
+      : undefined
+    if (!step) {
+      throw new ValidationError(`Part ${partId} is already completed, cannot attach cert`)
+    }
+    return { partId, stepId: step.id, jobId: part.jobId, pathId: part.pathId }
+  })
+
+  return certService.batchAttachCertWithSteps({
+    certId: body.certId,
+    attachments,
+    userId,
+  })
 })

--- a/server/api/certs/batch-attach.post.ts
+++ b/server/api/certs/batch-attach.post.ts
@@ -1,7 +1,10 @@
+import { batchAttachCertSchema } from '../../schemas/certSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Certificates'],
     description: 'Batch-attach a certificate to multiple parts.',
+    requestBody: zodRequestBody(batchAttachCertSchema),
     responses: {
       200: { description: 'Certificate attached to parts' },
       400: { description: 'Validation error' },
@@ -10,7 +13,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, batchAttachCertSchema)
   const userId = getAuthUserId(event)
   const { certService } = getServices()
   return certService.batchAttachCert({ ...body, userId })

--- a/server/api/certs/batch-attach.post.ts
+++ b/server/api/certs/batch-attach.post.ts
@@ -15,24 +15,6 @@ defineRouteMeta({
 export default defineApiHandler(async (event) => {
   const body = await parseBody(event, batchAttachCertSchema)
   const userId = getAuthUserId(event)
-  const { partService, pathService, certService } = getServices()
-
-  // Resolve each part's current step (same pattern as single attach-cert route)
-  const attachments = body.partIds.map((partId) => {
-    const part = partService.getPart(partId)
-    const path = pathService.getPath(part.pathId)
-    const step = part.currentStepId !== null
-      ? path.steps.find(s => s.id === part.currentStepId)
-      : undefined
-    if (!step) {
-      throw new ValidationError(`Part ${partId} is already completed, cannot attach cert`)
-    }
-    return { partId, stepId: step.id, jobId: part.jobId, pathId: part.pathId }
-  })
-
-  return certService.batchAttachCertWithSteps({
-    certId: body.certId,
-    attachments,
-    userId,
-  })
+  const { certService } = getServices()
+  return certService.batchAttachCert({ ...body, userId })
 })

--- a/server/api/certs/index.post.ts
+++ b/server/api/certs/index.post.ts
@@ -1,7 +1,10 @@
+import { createCertSchema } from '../../schemas/certSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Certificates'],
     description: 'Create a new certificate.',
+    requestBody: zodRequestBody(createCertSchema),
     responses: {
       201: { description: 'Certificate created' },
       400: { description: 'Validation error' },
@@ -10,7 +13,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, createCertSchema)
   const { certService } = getServices()
   return certService.createCert(body)
 })

--- a/server/api/jobs/[id].put.ts
+++ b/server/api/jobs/[id].put.ts
@@ -1,7 +1,10 @@
+import { updateJobSchema } from '../../schemas/jobSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Jobs'],
     description: 'Update an existing job.',
+    requestBody: zodRequestBody(updateJobSchema),
     responses: {
       200: { description: 'Job updated' },
       400: { description: 'Validation error' },
@@ -12,7 +15,7 @@ defineRouteMeta({
 
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, updateJobSchema)
   const { jobService } = getServices()
   return jobService.updateJob(id, body)
 })

--- a/server/api/jobs/index.post.ts
+++ b/server/api/jobs/index.post.ts
@@ -1,7 +1,10 @@
+import { createJobSchema } from '../../schemas/jobSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Jobs'],
     description: 'Create a new production job.',
+    requestBody: zodRequestBody(createJobSchema),
     responses: {
       201: { description: 'Job created' },
       400: { description: 'Validation error' },
@@ -10,7 +13,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, createJobSchema)
   const { jobService } = getServices()
   return jobService.createJob(body)
 })

--- a/server/api/jobs/priorities.patch.ts
+++ b/server/api/jobs/priorities.patch.ts
@@ -1,7 +1,10 @@
+import { updatePrioritiesSchema } from '../../schemas/jobSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Jobs'],
     description: 'Bulk-update job priority ordering.',
+    requestBody: zodRequestBody(updatePrioritiesSchema),
     responses: {
       200: { description: 'Priorities updated' },
       400: { description: 'Validation error' },
@@ -10,7 +13,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, updatePrioritiesSchema)
   const { jobService } = getServices()
   return jobService.updatePriorities(body)
 })

--- a/server/api/library/locations.post.ts
+++ b/server/api/library/locations.post.ts
@@ -1,7 +1,10 @@
+import { addLibraryEntrySchema } from '../../schemas/librarySchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Library'],
     description: 'Add a new location to the library.',
+    requestBody: zodRequestBody(addLibraryEntrySchema),
     responses: {
       201: { description: 'Location created' },
       400: { description: 'Validation error' },
@@ -10,7 +13,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, addLibraryEntrySchema)
   const { libraryService } = getServices()
   return libraryService.addLocation(body.name)
 })

--- a/server/api/library/processes.post.ts
+++ b/server/api/library/processes.post.ts
@@ -1,7 +1,10 @@
+import { addLibraryEntrySchema } from '../../schemas/librarySchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Library'],
     description: 'Add a new process to the library.',
+    requestBody: zodRequestBody(addLibraryEntrySchema),
     responses: {
       201: { description: 'Process created' },
       400: { description: 'Validation error' },
@@ -10,7 +13,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, addLibraryEntrySchema)
   const { libraryService } = getServices()
   return libraryService.addProcess(body.name)
 })

--- a/server/api/notes/index.post.ts
+++ b/server/api/notes/index.post.ts
@@ -1,7 +1,10 @@
+import { createNoteSchema } from '../../schemas/noteSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Notes'],
     description: 'Create a new step note.',
+    requestBody: zodRequestBody(createNoteSchema),
     responses: {
       201: { description: 'Note created' },
       400: { description: 'Validation error' },
@@ -10,13 +13,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody<{
-    jobId: string
-    pathId: string
-    stepId: string
-    partIds: string[]
-    text: string
-  }>(event)
+  const body = await parseBody(event, createNoteSchema)
   const userId = getAuthUserId(event)
   const { noteService } = getServices()
   return noteService.createNote({ ...body, userId })

--- a/server/api/parts/[id]/advance-to.post.ts
+++ b/server/api/parts/[id]/advance-to.post.ts
@@ -1,7 +1,10 @@
+import { advanceToStepSchema } from '../../../schemas/partSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Parts'],
     description: 'Advance a part to a specific target step.',
+    requestBody: zodRequestBody(advanceToStepSchema),
     responses: {
       200: { description: 'Part advanced to target step' },
       400: { description: 'Validation error' },
@@ -12,7 +15,7 @@ defineRouteMeta({
 
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, advanceToStepSchema)
   const userId = getAuthUserId(event)
   const { lifecycleService } = getServices()
   return lifecycleService.advanceToStep(id, { ...body, userId })

--- a/server/api/parts/[id]/attach-cert.post.ts
+++ b/server/api/parts/[id]/attach-cert.post.ts
@@ -1,7 +1,10 @@
+import { attachCertSchema } from '../../../schemas/partSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Parts'],
     description: 'Attach a certificate to a part at its current step.',
+    requestBody: zodRequestBody(attachCertSchema),
     responses: {
       200: { description: 'Certificate attached' },
       400: { description: 'Validation error or part already completed' },
@@ -12,7 +15,7 @@ defineRouteMeta({
 
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, attachCertSchema)
   const userId = getAuthUserId(event)
   const { partService, certService, pathService } = getServices()
 

--- a/server/api/parts/[id]/force-complete.post.ts
+++ b/server/api/parts/[id]/force-complete.post.ts
@@ -1,7 +1,10 @@
+import { forceCompleteSchema } from '../../../schemas/partSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Parts'],
     description: 'Force-complete a part, skipping remaining steps.',
+    requestBody: zodRequestBody(forceCompleteSchema),
     responses: {
       200: { description: 'Part force-completed' },
       400: { description: 'Validation error' },
@@ -12,7 +15,7 @@ defineRouteMeta({
 
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, forceCompleteSchema)
   const userId = getAuthUserId(event)
   const { lifecycleService } = getServices()
   return lifecycleService.forceComplete(id, { ...body, userId })

--- a/server/api/parts/[id]/overrides.post.ts
+++ b/server/api/parts/[id]/overrides.post.ts
@@ -1,7 +1,10 @@
+import { createOverrideSchema } from '../../../schemas/partSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Parts'],
     description: 'Create a step override for one or more parts.',
+    requestBody: zodRequestBody(createOverrideSchema),
     responses: {
       200: { description: 'Step override created' },
       400: { description: 'Validation error' },
@@ -10,8 +13,8 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, createOverrideSchema)
   const userId = getAuthUserId(event)
   const { lifecycleService } = getServices()
-  return lifecycleService.createStepOverride(body.partIds || body.serialIds, body.stepId, body.reason, userId)
+  return lifecycleService.createStepOverride(body.partIds || body.serialIds || [], body.stepId, body.reason, userId)
 })

--- a/server/api/parts/[id]/overrides.post.ts
+++ b/server/api/parts/[id]/overrides.post.ts
@@ -16,5 +16,5 @@ export default defineApiHandler(async (event) => {
   const body = await parseBody(event, createOverrideSchema)
   const userId = getAuthUserId(event)
   const { lifecycleService } = getServices()
-  return lifecycleService.createStepOverride(body.partIds || body.serialIds || [], body.stepId, body.reason, userId)
+  return lifecycleService.createStepOverride(body.partIds || body.serialIds!, body.stepId, body.reason, userId)
 })

--- a/server/api/parts/[id]/scrap.post.ts
+++ b/server/api/parts/[id]/scrap.post.ts
@@ -1,7 +1,10 @@
+import { scrapPartSchema } from '../../../schemas/partSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Parts'],
     description: 'Scrap a part with a reason.',
+    requestBody: zodRequestBody(scrapPartSchema),
     responses: {
       200: { description: 'Part scrapped' },
       400: { description: 'Validation error' },
@@ -12,7 +15,7 @@ defineRouteMeta({
 
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, scrapPartSchema)
   const userId = getAuthUserId(event)
   const { lifecycleService } = getServices()
   return lifecycleService.scrapPart(id, { ...body, userId })

--- a/server/api/parts/index.post.ts
+++ b/server/api/parts/index.post.ts
@@ -1,7 +1,10 @@
+import { createPartsSchema } from '../../schemas/partSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Parts'],
     description: 'Batch-create parts for a path.',
+    requestBody: zodRequestBody(createPartsSchema),
     responses: {
       201: { description: 'Parts created' },
       400: { description: 'Validation error' },
@@ -10,7 +13,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, createPartsSchema)
   const userId = getAuthUserId(event)
   const { partService } = getServices()
   return partService.batchCreateParts(body, userId)

--- a/server/api/settings/index.put.ts
+++ b/server/api/settings/index.put.ts
@@ -1,7 +1,10 @@
+import { updateSettingsSchema } from '../../schemas/settingsSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Settings'],
     description: 'Update application settings.',
+    requestBody: zodRequestBody(updateSettingsSchema),
     responses: {
       200: { description: 'Settings updated' },
       400: { description: 'Validation error' },
@@ -10,7 +13,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, updateSettingsSchema)
   const { settingsService } = getServices()
   return settingsService.updateSettings(body)
 })

--- a/server/api/templates/[id].put.ts
+++ b/server/api/templates/[id].put.ts
@@ -1,7 +1,10 @@
+import { updateTemplateSchema } from '../../schemas/templateSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Templates'],
     description: 'Update a route template.',
+    requestBody: zodRequestBody(updateTemplateSchema),
     responses: {
       200: { description: 'Template updated' },
       400: { description: 'Validation error' },
@@ -12,7 +15,7 @@ defineRouteMeta({
 
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, updateTemplateSchema)
   const { templateService } = getServices()
   return templateService.updateTemplate(id, body)
 })

--- a/server/api/templates/[id]/apply.post.ts
+++ b/server/api/templates/[id]/apply.post.ts
@@ -1,7 +1,10 @@
+import { applyTemplateSchema } from '../../../schemas/templateSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Templates'],
     description: 'Apply a template to create a path on a job.',
+    requestBody: zodRequestBody(applyTemplateSchema),
     responses: {
       201: { description: 'Path created from template' },
       400: { description: 'Validation error' },
@@ -12,7 +15,7 @@ defineRouteMeta({
 
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, applyTemplateSchema)
   const { templateService } = getServices()
   return templateService.applyTemplate(id, body)
 })

--- a/server/api/templates/index.post.ts
+++ b/server/api/templates/index.post.ts
@@ -1,7 +1,10 @@
+import { createTemplateSchema } from '../../schemas/templateSchemas'
+
 defineRouteMeta({
   openAPI: {
     tags: ['Templates'],
     description: 'Create a new route template.',
+    requestBody: zodRequestBody(createTemplateSchema),
     responses: {
       201: { description: 'Template created' },
       400: { description: 'Validation error' },
@@ -10,7 +13,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, createTemplateSchema)
   const { templateService } = getServices()
   return templateService.createTemplate(body)
 })

--- a/server/api/users/[id].put.ts
+++ b/server/api/users/[id].put.ts
@@ -1,9 +1,11 @@
 import { toPublicUser } from '../../types/domain'
+import { updateUserSchema } from '../../schemas/userSchemas'
 
 defineRouteMeta({
   openAPI: {
     tags: ['Users'],
     description: 'Update a user by ID.',
+    requestBody: zodRequestBody(updateUserSchema),
     responses: {
       200: { description: 'User updated' },
       400: { description: 'Validation error' },
@@ -14,7 +16,7 @@ defineRouteMeta({
 
 export default defineApiHandler(async (event) => {
   const id = getRouterParam(event, 'id')!
-  const body = await readBody(event)
+  const body = await parseBody(event, updateUserSchema)
   const { userService } = getServices()
   return toPublicUser(userService.updateUser(id, body))
 })

--- a/server/api/users/index.post.ts
+++ b/server/api/users/index.post.ts
@@ -1,9 +1,11 @@
 import { toPublicUser } from '../../types/domain'
+import { createUserSchema } from '../../schemas/userSchemas'
 
 defineRouteMeta({
   openAPI: {
     tags: ['Users'],
     description: 'Create a new user.',
+    requestBody: zodRequestBody(createUserSchema),
     responses: {
       201: { description: 'User created' },
       400: { description: 'Validation error' },
@@ -12,7 +14,7 @@ defineRouteMeta({
 })
 
 export default defineApiHandler(async (event) => {
-  const body = await readBody(event)
+  const body = await parseBody(event, createUserSchema)
   const { userService } = getServices()
   return toPublicUser(userService.createUser(body))
 })

--- a/server/schemas/_primitives.ts
+++ b/server/schemas/_primitives.ts
@@ -3,34 +3,36 @@
  *
  * Centralizes frequently-reused field schemas so domain schema files
  * can import them instead of re-declaring the same patterns.
- * Prefix-free — consumers import named constants directly.
+ *
+ * Domain enums are derived from the const arrays in `server/types/domain.ts`
+ * — that file is the single source of truth for allowed values. Adding a new
+ * enum variant there automatically updates both the TypeScript type and the
+ * Zod schema.
  */
 import { z } from 'zod'
+import {
+  ADVANCEMENT_MODES,
+  DEPENDENCY_TYPES,
+  SCRAP_REASONS,
+  CERT_TYPES,
+} from '../types/domain'
 
 // ── ID fields ──
 
 /** Non-empty string ID. Use for any required entity reference (jobId, pathId, stepId, etc.). */
 export const requiredId = z.string().min(1)
 
-// ── Domain enums ──
+// ── Domain enums (derived from domain.ts const arrays) ──
 
-export const dependencyTypeEnum = z.enum(['physical', 'preferred', 'completion_gate'])
-export const advancementModeEnum = z.enum(['strict', 'flexible', 'per_step'])
-export const scrapReasonEnum = z.enum(['out_of_tolerance', 'process_defect', 'damaged', 'operator_error', 'other'])
-export const certTypeEnum = z.enum(['material', 'process'])
+export const dependencyTypeEnum = z.enum(DEPENDENCY_TYPES)
+export const advancementModeEnum = z.enum(ADVANCEMENT_MODES)
+export const scrapReasonEnum = z.enum(SCRAP_REASONS)
+export const certTypeEnum = z.enum(CERT_TYPES)
 
 // ── Numeric fields ──
 
 /** Positive integer (> 0). Use for goalQuantity, requiredQuantity, priority, etc. */
 export const positiveInt = z.number().int().positive()
-
-// ── Batch ID arrays ──
-
-/** Array of 1–100 non-empty ID strings. Use for standard batch operations. */
-export const batchIds100 = z.array(requiredId).min(1).max(100)
-
-/** Array of 1–500 non-empty ID strings. Use for larger read-only batch fetches. */
-export const batchIds500 = z.array(requiredId).min(1).max(500)
 
 // ── Auth ──
 

--- a/server/schemas/_primitives.ts
+++ b/server/schemas/_primitives.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared Zod primitives for schema composition.
+ *
+ * Centralizes frequently-reused field schemas so domain schema files
+ * can import them instead of re-declaring the same patterns.
+ * Prefix-free — consumers import named constants directly.
+ */
+import { z } from 'zod'
+
+// ── ID fields ──
+
+/** Non-empty string ID. Use for any required entity reference (jobId, pathId, stepId, etc.). */
+export const requiredId = z.string().min(1)
+
+// ── Domain enums ──
+
+export const dependencyTypeEnum = z.enum(['physical', 'preferred', 'completion_gate'])
+export const advancementModeEnum = z.enum(['strict', 'flexible', 'per_step'])
+export const scrapReasonEnum = z.enum(['out_of_tolerance', 'process_defect', 'damaged', 'operator_error', 'other'])
+export const certTypeEnum = z.enum(['material', 'process'])
+
+// ── Numeric fields ──
+
+/** Positive integer (> 0). Use for goalQuantity, requiredQuantity, priority, etc. */
+export const positiveInt = z.number().int().positive()
+
+// ── Batch ID arrays ──
+
+/** Array of 1–100 non-empty ID strings. Use for standard batch operations. */
+export const batchIds100 = z.array(requiredId).min(1).max(100)
+
+/** Array of 1–500 non-empty ID strings. Use for larger read-only batch fetches. */
+export const batchIds500 = z.array(requiredId).min(1).max(500)
+
+// ── Auth ──
+
+/** 4-digit PIN string. */
+export const pinSchema = z.string().regex(/^\d{4}$/, 'PIN must be exactly 4 digits')

--- a/server/schemas/authSchemas.ts
+++ b/server/schemas/authSchemas.ts
@@ -1,17 +1,21 @@
+/**
+ * Zod schemas for auth API endpoints.
+ */
 import { z } from 'zod'
+import { requiredId, pinSchema } from './_primitives'
 
 export const loginSchema = z.object({
   username: z.string().min(1, 'username is required'),
-  pin: z.string().regex(/^\d{4}$/, 'PIN must be exactly 4 digits'),
+  pin: pinSchema,
 })
 
 export const setupPinSchema = z.object({
-  userId: z.string().min(1, 'userId is required'),
-  pin: z.string().regex(/^\d{4}$/, 'PIN must be exactly 4 digits'),
+  userId: requiredId,
+  pin: pinSchema,
 })
 
 export const resetPinSchema = z.object({
-  targetUserId: z.string().min(1, 'targetUserId is required'),
+  targetUserId: requiredId,
 })
 
 export const refreshTokenSchema = z.object({

--- a/server/schemas/bomSchemas.ts
+++ b/server/schemas/bomSchemas.ts
@@ -5,9 +5,10 @@
  * receive correctly-typed inputs.
  */
 import { z } from 'zod'
+import { requiredId } from './_primitives'
 
 const bomEntrySchema = z.object({
-  jobId: z.string().min(1, 'jobId is required'),
+  jobId: requiredId,
   requiredQuantity: z.number()
     .int('requiredQuantity must be an integer')
     .min(1, 'requiredQuantity must be at least 1')

--- a/server/schemas/certSchemas.ts
+++ b/server/schemas/certSchemas.ts
@@ -1,0 +1,19 @@
+/**
+ * Zod schemas for certificate API endpoints.
+ *
+ * These schemas validate request inputs at the API boundary, ensuring services
+ * receive correctly-typed inputs.
+ */
+import { z } from 'zod'
+
+export const createCertSchema = z.object({
+  type: z.enum(['material', 'process']),
+  name: z.string().min(1, 'name is required'),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const batchAttachCertSchema = z.object({
+  certId: z.string().min(1, 'certId is required'),
+  partIds: z.array(z.string().min(1)).min(1, 'At least one partId is required'),
+  stepId: z.string().min(1, 'stepId is required'),
+})

--- a/server/schemas/certSchemas.ts
+++ b/server/schemas/certSchemas.ts
@@ -5,15 +5,16 @@
  * receive correctly-typed inputs.
  */
 import { z } from 'zod'
+import { requiredId, certTypeEnum } from './_primitives'
 
 export const createCertSchema = z.object({
-  type: z.enum(['material', 'process']),
+  type: certTypeEnum,
   name: z.string().min(1, 'name is required'),
   metadata: z.record(z.string(), z.unknown()).optional(),
 })
 
 export const batchAttachCertSchema = z.object({
-  certId: z.string().min(1, 'certId is required'),
-  partIds: z.array(z.string().min(1)).min(1, 'At least one partId is required'),
-  stepId: z.string().min(1, 'stepId is required'),
+  certId: requiredId,
+  partIds: z.array(requiredId).min(1, 'At least one partId is required'),
+  stepId: requiredId,
 })

--- a/server/schemas/certSchemas.ts
+++ b/server/schemas/certSchemas.ts
@@ -16,5 +16,4 @@ export const createCertSchema = z.object({
 export const batchAttachCertSchema = z.object({
   certId: requiredId,
   partIds: z.array(requiredId).min(1, 'At least one partId is required'),
-  stepId: requiredId,
 })

--- a/server/schemas/jiraSchemas.ts
+++ b/server/schemas/jiraSchemas.ts
@@ -5,18 +5,19 @@
  * ensuring services receive correctly-typed inputs.
  */
 import { z } from 'zod'
+import { requiredId, positiveInt } from './_primitives'
 
 export const pushJiraCommentSchema = z.object({
-  jobId: z.string().min(1, 'jobId is required'),
-  noteId: z.string().min(1).optional(),
+  jobId: requiredId,
+  noteId: requiredId.optional(),
 })
 
 export const linkJiraTicketSchema = z.object({
   ticketKey: z.string().min(1, 'ticketKey is required'),
-  goalQuantity: z.number().int().positive('goalQuantity must be a positive integer').optional(),
-  templateId: z.string().min(1).optional(),
+  goalQuantity: positiveInt.optional(),
+  templateId: requiredId.optional(),
 })
 
 export const jiraPushSchema = z.object({
-  jobId: z.string().min(1, 'jobId is required'),
+  jobId: requiredId,
 })

--- a/server/schemas/jobSchemas.ts
+++ b/server/schemas/jobSchemas.ts
@@ -1,0 +1,30 @@
+/**
+ * Zod schemas for job API endpoints.
+ *
+ * These schemas validate request inputs at the API boundary, ensuring services
+ * receive correctly-typed inputs.
+ */
+import { z } from 'zod'
+
+export const createJobSchema = z.object({
+  name: z.string().min(1, 'name is required'),
+  goalQuantity: z.number().int().positive('goalQuantity must be a positive integer'),
+  jiraTicketKey: z.string().optional(),
+  jiraTicketSummary: z.string().optional(),
+  jiraPartNumber: z.string().optional(),
+  jiraPriority: z.string().optional(),
+  jiraEpicLink: z.string().optional(),
+  jiraLabels: z.array(z.string()).optional(),
+})
+
+export const updateJobSchema = z.object({
+  name: z.string().min(1).optional(),
+  goalQuantity: z.number().int().positive('goalQuantity must be a positive integer').optional(),
+})
+
+export const updatePrioritiesSchema = z.object({
+  priorities: z.array(z.object({
+    jobId: z.string().min(1, 'jobId is required'),
+    priority: z.number().int().positive('priority must be a positive integer'),
+  })).min(1, 'At least one priority entry is required'),
+})

--- a/server/schemas/jobSchemas.ts
+++ b/server/schemas/jobSchemas.ts
@@ -5,10 +5,11 @@
  * receive correctly-typed inputs.
  */
 import { z } from 'zod'
+import { requiredId, positiveInt } from './_primitives'
 
 export const createJobSchema = z.object({
   name: z.string().min(1, 'name is required'),
-  goalQuantity: z.number().int().positive('goalQuantity must be a positive integer'),
+  goalQuantity: positiveInt,
   jiraTicketKey: z.string().optional(),
   jiraTicketSummary: z.string().optional(),
   jiraPartNumber: z.string().optional(),
@@ -19,12 +20,12 @@ export const createJobSchema = z.object({
 
 export const updateJobSchema = z.object({
   name: z.string().min(1).optional(),
-  goalQuantity: z.number().int().positive('goalQuantity must be a positive integer').optional(),
+  goalQuantity: positiveInt.optional(),
 })
 
 export const updatePrioritiesSchema = z.object({
   priorities: z.array(z.object({
-    jobId: z.string().min(1, 'jobId is required'),
-    priority: z.number().int().positive('priority must be a positive integer'),
+    jobId: requiredId,
+    priority: positiveInt,
   })).min(1, 'At least one priority entry is required'),
 })

--- a/server/schemas/librarySchemas.ts
+++ b/server/schemas/librarySchemas.ts
@@ -1,0 +1,11 @@
+/**
+ * Zod schemas for library API endpoints.
+ *
+ * These schemas validate request inputs at the API boundary, ensuring services
+ * receive correctly-typed inputs.
+ */
+import { z } from 'zod'
+
+export const addLibraryEntrySchema = z.object({
+  name: z.string().min(1, 'name is required'),
+})

--- a/server/schemas/noteSchemas.ts
+++ b/server/schemas/noteSchemas.ts
@@ -1,0 +1,16 @@
+/**
+ * Zod schemas for note API endpoints.
+ *
+ * These schemas validate request inputs at the API boundary, ensuring services
+ * receive correctly-typed inputs.
+ */
+import { z } from 'zod'
+import { requiredId } from './_primitives'
+
+export const createNoteSchema = z.object({
+  jobId: requiredId,
+  pathId: requiredId,
+  stepId: requiredId,
+  partIds: z.array(requiredId).min(1, 'At least one partId is required'),
+  text: z.string().min(1, 'text is required'),
+})

--- a/server/schemas/partSchemas.ts
+++ b/server/schemas/partSchemas.ts
@@ -5,7 +5,7 @@
  * receive correctly-typed inputs.
  */
 import { z } from 'zod'
-import { requiredId, positiveInt, scrapReasonEnum, batchIds100, batchIds500 } from './_primitives'
+import { requiredId, positiveInt, scrapReasonEnum } from './_primitives'
 
 /**
  * Validates the `id` route param for single-part endpoints such as
@@ -22,7 +22,9 @@ export const partIdParamSchema = z.object({
  * Accepts an array of 1–100 non-empty part ID strings.
  */
 export const batchAdvanceSchema = z.object({
-  partIds: batchIds100,
+  partIds: z.array(requiredId)
+    .min(1, 'At least one part ID is required')
+    .max(100, 'Cannot advance more than 100 parts at once'),
 })
 
 /**
@@ -30,7 +32,9 @@ export const batchAdvanceSchema = z.object({
  * Accepts an array of 1–500 non-empty part ID strings.
  */
 export const batchStepStatusesSchema = z.object({
-  partIds: batchIds500,
+  partIds: z.array(requiredId)
+    .min(1, 'At least one part ID is required')
+    .max(500, 'Cannot fetch more than 500 parts at once'),
 })
 
 /**
@@ -38,7 +42,9 @@ export const batchStepStatusesSchema = z.object({
  * Accepts an array of 1–100 part IDs, a target step ID, and an optional skip flag.
  */
 export const batchAdvanceToSchema = z.object({
-  partIds: batchIds100,
+  partIds: z.array(requiredId)
+    .min(1, 'At least one part ID is required')
+    .max(100, 'Cannot advance more than 100 parts at once'),
   targetStepId: requiredId,
   skip: z.boolean().optional(),
 })

--- a/server/schemas/partSchemas.ts
+++ b/server/schemas/partSchemas.ts
@@ -88,10 +88,14 @@ export const advanceToStepSchema = z.object({
  */
 export const createOverrideSchema = z.object({
   partIds: z.array(requiredId).min(1, 'At least one partId is required').optional(),
+  /** @deprecated Use `partIds` instead. Kept for backward compatibility. */
   serialIds: z.array(requiredId).min(1).optional(),
   stepId: requiredId,
   reason: z.string().min(1, 'reason is required'),
-})
+}).refine(
+  data => (data.partIds && data.partIds.length > 0) || (data.serialIds && data.serialIds.length > 0),
+  { message: 'At least one of partIds or serialIds must be provided', path: ['partIds'] },
+)
 
 /**
  * Validates the request body for `POST /api/parts/:id/attach-cert`.

--- a/server/schemas/partSchemas.ts
+++ b/server/schemas/partSchemas.ts
@@ -51,6 +51,57 @@ export const batchAdvanceToSchema = z.object({
 })
 
 /**
+ * Validates the request body for `POST /api/parts`.
+ * Batch-create parts for a path.
+ */
+export const createPartsSchema = z.object({
+  jobId: z.string().min(1, 'jobId is required'),
+  pathId: z.string().min(1, 'pathId is required'),
+  quantity: z.number().int().positive('quantity must be a positive integer'),
+  certId: z.string().min(1).optional(),
+})
+
+/**
+ * Validates the request body for `POST /api/parts/:id/scrap`.
+ */
+export const scrapPartSchema = z.object({
+  reason: z.enum(['out_of_tolerance', 'process_defect', 'damaged', 'operator_error', 'other']),
+  explanation: z.string().optional(),
+})
+
+/**
+ * Validates the request body for `POST /api/parts/:id/force-complete`.
+ */
+export const forceCompleteSchema = z.object({
+  reason: z.string().optional(),
+})
+
+/**
+ * Validates the request body for `POST /api/parts/:id/advance-to`.
+ */
+export const advanceToStepSchema = z.object({
+  targetStepId: z.string().min(1, 'targetStepId is required'),
+  skip: z.boolean().optional(),
+})
+
+/**
+ * Validates the request body for `POST /api/parts/:id/overrides`.
+ */
+export const createOverrideSchema = z.object({
+  partIds: z.array(z.string().min(1)).min(1, 'At least one partId is required').optional(),
+  serialIds: z.array(z.string().min(1)).min(1).optional(),
+  stepId: z.string().min(1, 'stepId is required'),
+  reason: z.string().min(1, 'reason is required'),
+})
+
+/**
+ * Validates the request body for `POST /api/parts/:id/attach-cert`.
+ */
+export const attachCertSchema = z.object({
+  certId: z.string().min(1, 'certId is required'),
+})
+
+/**
  * Validates the request body for `POST /api/parts/:id/waive-step/:stepId`.
  */
 export const waiveStepSchema = z.object({

--- a/server/schemas/partSchemas.ts
+++ b/server/schemas/partSchemas.ts
@@ -5,6 +5,7 @@
  * receive correctly-typed inputs.
  */
 import { z } from 'zod'
+import { requiredId, positiveInt, scrapReasonEnum, batchIds100, batchIds500 } from './_primitives'
 
 /**
  * Validates the `id` route param for single-part endpoints such as
@@ -21,11 +22,7 @@ export const partIdParamSchema = z.object({
  * Accepts an array of 1–100 non-empty part ID strings.
  */
 export const batchAdvanceSchema = z.object({
-  partIds: z.array(
-    z.string().min(1, { error: 'Part ID must be non-empty' }),
-  )
-    .min(1, { error: 'At least one part ID is required' })
-    .max(100, { error: 'Cannot advance more than 100 parts at once' }),
+  partIds: batchIds100,
 })
 
 /**
@@ -33,9 +30,7 @@ export const batchAdvanceSchema = z.object({
  * Accepts an array of 1–500 non-empty part ID strings.
  */
 export const batchStepStatusesSchema = z.object({
-  partIds: z.array(z.string().min(1))
-    .min(1, 'At least one part ID is required')
-    .max(500, 'Cannot fetch more than 500 parts at once'),
+  partIds: batchIds500,
 })
 
 /**
@@ -43,10 +38,8 @@ export const batchStepStatusesSchema = z.object({
  * Accepts an array of 1–100 part IDs, a target step ID, and an optional skip flag.
  */
 export const batchAdvanceToSchema = z.object({
-  partIds: z.array(z.string().min(1))
-    .min(1, 'At least one part ID is required')
-    .max(100, 'Cannot advance more than 100 parts at once'),
-  targetStepId: z.string().min(1, 'targetStepId is required'),
+  partIds: batchIds100,
+  targetStepId: requiredId,
   skip: z.boolean().optional(),
 })
 
@@ -55,17 +48,17 @@ export const batchAdvanceToSchema = z.object({
  * Batch-create parts for a path.
  */
 export const createPartsSchema = z.object({
-  jobId: z.string().min(1, 'jobId is required'),
-  pathId: z.string().min(1, 'pathId is required'),
-  quantity: z.number().int().positive('quantity must be a positive integer'),
-  certId: z.string().min(1).optional(),
+  jobId: requiredId,
+  pathId: requiredId,
+  quantity: positiveInt,
+  certId: requiredId.optional(),
 })
 
 /**
  * Validates the request body for `POST /api/parts/:id/scrap`.
  */
 export const scrapPartSchema = z.object({
-  reason: z.enum(['out_of_tolerance', 'process_defect', 'damaged', 'operator_error', 'other']),
+  reason: scrapReasonEnum,
   explanation: z.string().optional(),
 })
 
@@ -80,7 +73,7 @@ export const forceCompleteSchema = z.object({
  * Validates the request body for `POST /api/parts/:id/advance-to`.
  */
 export const advanceToStepSchema = z.object({
-  targetStepId: z.string().min(1, 'targetStepId is required'),
+  targetStepId: requiredId,
   skip: z.boolean().optional(),
 })
 
@@ -88,9 +81,9 @@ export const advanceToStepSchema = z.object({
  * Validates the request body for `POST /api/parts/:id/overrides`.
  */
 export const createOverrideSchema = z.object({
-  partIds: z.array(z.string().min(1)).min(1, 'At least one partId is required').optional(),
-  serialIds: z.array(z.string().min(1)).min(1).optional(),
-  stepId: z.string().min(1, 'stepId is required'),
+  partIds: z.array(requiredId).min(1, 'At least one partId is required').optional(),
+  serialIds: z.array(requiredId).min(1).optional(),
+  stepId: requiredId,
   reason: z.string().min(1, 'reason is required'),
 })
 
@@ -98,7 +91,7 @@ export const createOverrideSchema = z.object({
  * Validates the request body for `POST /api/parts/:id/attach-cert`.
  */
 export const attachCertSchema = z.object({
-  certId: z.string().min(1, 'certId is required'),
+  certId: requiredId,
 })
 
 /**

--- a/server/schemas/pathSchemas.ts
+++ b/server/schemas/pathSchemas.ts
@@ -5,9 +5,7 @@
  * ensuring services receive correctly-typed inputs.
  */
 import { z } from 'zod'
-
-const dependencyTypeEnum = z.enum(['physical', 'preferred', 'completion_gate'])
-const advancementModeEnum = z.enum(['strict', 'flexible', 'per_step'])
+import { requiredId, positiveInt, dependencyTypeEnum, advancementModeEnum } from './_primitives'
 
 /**
  * Validates the `id` route param for single-path endpoints.
@@ -29,16 +27,16 @@ const stepInputSchema = z.object({
 })
 
 export const createPathSchema = z.object({
-  jobId: z.string().min(1, 'jobId is required'),
+  jobId: requiredId,
   name: z.string().min(1, 'name is required'),
-  goalQuantity: z.number().int().positive('goalQuantity must be a positive integer'),
+  goalQuantity: positiveInt,
   advancementMode: advancementModeEnum.optional(),
   steps: z.array(stepInputSchema).min(1, 'At least one step is required'),
 })
 
 export const updatePathSchema = z.object({
   name: z.string().min(1).optional(),
-  goalQuantity: z.number().int().positive().optional(),
+  goalQuantity: positiveInt.optional(),
   advancementMode: advancementModeEnum.optional(),
   steps: z.array(stepInputSchema).min(1).optional(),
 })
@@ -61,7 +59,7 @@ export const updateStepConfigSchema = z.object({
 )
 
 export const batchDistributionsSchema = z.object({
-  pathIds: z.array(z.string().min(1))
+  pathIds: z.array(requiredId)
     .min(1, 'At least one path ID is required')
     .max(100, 'Cannot fetch more than 100 paths at once'),
 })
@@ -70,15 +68,15 @@ export const batchDistributionsSchema = z.object({
 
 const batchPathCreateSchema = z.object({
   name: z.string().min(1, 'name is required'),
-  goalQuantity: z.number().int().positive('goalQuantity must be a positive integer'),
+  goalQuantity: positiveInt,
   advancementMode: advancementModeEnum.optional(),
   steps: z.array(stepInputSchema).min(1, 'At least one step is required'),
 })
 
 const batchPathUpdateSchema = z.object({
-  pathId: z.string().min(1, 'pathId is required'),
+  pathId: requiredId,
   name: z.string().min(1).optional(),
-  goalQuantity: z.number().int().positive().optional(),
+  goalQuantity: positiveInt.optional(),
   advancementMode: advancementModeEnum.optional(),
   steps: z.array(stepInputSchema).min(1).optional(),
 })
@@ -86,7 +84,7 @@ const batchPathUpdateSchema = z.object({
 export const batchPathOperationsSchema = z.object({
   create: z.array(batchPathCreateSchema).default([]),
   update: z.array(batchPathUpdateSchema).default([]),
-  delete: z.array(z.string().min(1)).default([]),
+  delete: z.array(requiredId).default([]),
 }).refine(
   data => data.create.length + data.update.length + data.delete.length > 0,
   { message: 'At least one operation (create, update, or delete) is required' },

--- a/server/schemas/settingsSchemas.ts
+++ b/server/schemas/settingsSchemas.ts
@@ -1,0 +1,42 @@
+/**
+ * Zod schemas for settings API endpoints.
+ *
+ * These schemas validate request inputs at the API boundary, ensuring services
+ * receive correctly-typed inputs.
+ */
+import { z } from 'zod'
+
+const jiraConnectionSchema = z.object({
+  baseUrl: z.string().optional(),
+  projectKey: z.string().optional(),
+  username: z.string().optional(),
+  apiToken: z.string().optional(),
+  enabled: z.boolean().optional(),
+  pushEnabled: z.boolean().optional(),
+})
+
+const jiraFieldMappingSchema = z.object({
+  id: z.string().min(1),
+  jiraFieldId: z.string().min(1),
+  label: z.string().min(1),
+  shopErpField: z.string().min(1),
+  isDefault: z.boolean(),
+})
+
+const pageTogglesSchema = z.object({
+  jobs: z.boolean().optional(),
+  partsBrowser: z.boolean().optional(),
+  parts: z.boolean().optional(),
+  queue: z.boolean().optional(),
+  templates: z.boolean().optional(),
+  bom: z.boolean().optional(),
+  certs: z.boolean().optional(),
+  jira: z.boolean().optional(),
+  audit: z.boolean().optional(),
+})
+
+export const updateSettingsSchema = z.object({
+  jiraConnection: jiraConnectionSchema.optional(),
+  jiraFieldMappings: z.array(jiraFieldMappingSchema).optional(),
+  pageToggles: pageTogglesSchema.optional(),
+})

--- a/server/schemas/templateSchemas.ts
+++ b/server/schemas/templateSchemas.ts
@@ -10,9 +10,6 @@ import { requiredId, positiveInt, dependencyTypeEnum } from './_primitives'
 const templateStepSchema = z.object({
   name: z.string().min(1, 'Step name is required'),
   location: z.string().optional(),
-})
-
-const templateStepWithOptionsSchema = templateStepSchema.extend({
   optional: z.boolean().optional(),
   dependencyType: dependencyTypeEnum.optional(),
 })
@@ -24,7 +21,7 @@ export const createTemplateSchema = z.object({
 
 export const updateTemplateSchema = z.object({
   name: z.string().min(1).optional(),
-  steps: z.array(templateStepWithOptionsSchema).min(1).optional(),
+  steps: z.array(templateStepSchema).min(1).optional(),
 })
 
 export const applyTemplateSchema = z.object({

--- a/server/schemas/templateSchemas.ts
+++ b/server/schemas/templateSchemas.ts
@@ -1,0 +1,35 @@
+/**
+ * Zod schemas for template API endpoints.
+ *
+ * These schemas validate request inputs at the API boundary, ensuring services
+ * receive correctly-typed inputs.
+ */
+import { z } from 'zod'
+
+const templateStepSchema = z.object({
+  name: z.string().min(1, 'Step name is required'),
+  location: z.string().optional(),
+})
+
+const templateStepWithOptionsSchema = z.object({
+  name: z.string().min(1, 'Step name is required'),
+  location: z.string().optional(),
+  optional: z.boolean().optional(),
+  dependencyType: z.enum(['physical', 'preferred', 'completion_gate']).optional(),
+})
+
+export const createTemplateSchema = z.object({
+  name: z.string().min(1, 'name is required'),
+  steps: z.array(templateStepSchema).min(1, 'At least one step is required'),
+})
+
+export const updateTemplateSchema = z.object({
+  name: z.string().min(1).optional(),
+  steps: z.array(templateStepWithOptionsSchema).min(1).optional(),
+})
+
+export const applyTemplateSchema = z.object({
+  jobId: z.string().min(1, 'jobId is required'),
+  pathName: z.string().optional(),
+  goalQuantity: z.number().int().positive('goalQuantity must be a positive integer'),
+})

--- a/server/schemas/templateSchemas.ts
+++ b/server/schemas/templateSchemas.ts
@@ -5,17 +5,16 @@
  * receive correctly-typed inputs.
  */
 import { z } from 'zod'
+import { requiredId, positiveInt, dependencyTypeEnum } from './_primitives'
 
 const templateStepSchema = z.object({
   name: z.string().min(1, 'Step name is required'),
   location: z.string().optional(),
 })
 
-const templateStepWithOptionsSchema = z.object({
-  name: z.string().min(1, 'Step name is required'),
-  location: z.string().optional(),
+const templateStepWithOptionsSchema = templateStepSchema.extend({
   optional: z.boolean().optional(),
-  dependencyType: z.enum(['physical', 'preferred', 'completion_gate']).optional(),
+  dependencyType: dependencyTypeEnum.optional(),
 })
 
 export const createTemplateSchema = z.object({
@@ -29,7 +28,7 @@ export const updateTemplateSchema = z.object({
 })
 
 export const applyTemplateSchema = z.object({
-  jobId: z.string().min(1, 'jobId is required'),
+  jobId: requiredId,
   pathName: z.string().optional(),
-  goalQuantity: z.number().int().positive('goalQuantity must be a positive integer'),
+  goalQuantity: positiveInt,
 })

--- a/server/schemas/userSchemas.ts
+++ b/server/schemas/userSchemas.ts
@@ -9,10 +9,14 @@ import { z } from 'zod'
 export const createUserSchema = z.object({
   username: z.string().min(1, 'username is required'),
   displayName: z.string().min(1, 'displayName is required'),
+  department: z.string().optional(),
   isAdmin: z.boolean().optional(),
 })
 
 export const updateUserSchema = z.object({
+  username: z.string().min(1).optional(),
   displayName: z.string().min(1).optional(),
+  department: z.string().optional(),
+  active: z.boolean().optional(),
   isAdmin: z.boolean().optional(),
 })

--- a/server/schemas/userSchemas.ts
+++ b/server/schemas/userSchemas.ts
@@ -1,0 +1,18 @@
+/**
+ * Zod schemas for user API endpoints.
+ *
+ * These schemas validate request inputs at the API boundary, ensuring services
+ * receive correctly-typed inputs.
+ */
+import { z } from 'zod'
+
+export const createUserSchema = z.object({
+  username: z.string().min(1, 'username is required'),
+  displayName: z.string().min(1, 'displayName is required'),
+  isAdmin: z.boolean().optional(),
+})
+
+export const updateUserSchema = z.object({
+  displayName: z.string().min(1).optional(),
+  isAdmin: z.boolean().optional(),
+})

--- a/server/scripts/seed.ts
+++ b/server/scripts/seed.ts
@@ -79,7 +79,7 @@ function createServices(db: Database.Database) {
     auditService,
     partIdGenerator,
   )
-  const certService = createCertService({ certs: repos.certs }, auditService)
+  const certService = createCertService({ certs: repos.certs, parts: repos.parts, paths: repos.paths }, auditService)
   const templateService = createTemplateService({ templates: repos.templates, paths: repos.paths })
   const noteService = createNoteService({ notes: repos.notes }, auditService)
   const userService = createUserService({ users: repos.users })

--- a/server/services/certService.ts
+++ b/server/services/certService.ts
@@ -87,30 +87,50 @@ export function createCertService(
       })
     },
 
+    /** @deprecated Use `batchAttachCertWithSteps` instead — this method sets stepId to empty string which violates the FK constraint. */
     batchAttachCert(input: BatchAttachCertInput): CertAttachment[] {
+      return this.batchAttachCertWithSteps({
+        certId: input.certId,
+        attachments: input.partIds.map(partId => ({ partId, stepId: '' })),
+        userId: input.userId,
+      })
+    },
+
+    batchAttachCertWithSteps(input: {
+      certId: string
+      attachments: readonly { partId: string, stepId: string, jobId?: string, pathId?: string }[]
+      userId: string
+    }): CertAttachment[] {
       const cert = repos.certs.getById(input.certId)
       if (!cert) {
         throw new NotFoundError('Certificate', input.certId)
       }
 
       const now = new Date().toISOString()
-      const attachments: CertAttachment[] = input.partIds.map(partId => ({
-        partId,
+      const rows: CertAttachment[] = input.attachments.map(a => ({
+        partId: a.partId,
         certId: input.certId,
-        stepId: '',
+        stepId: a.stepId,
         attachedAt: now,
         attachedBy: input.userId,
       }))
 
-      const results = repos.certs.batchAttach(attachments)
+      const results = repos.certs.batchAttach(rows)
 
-      // Record audit for each new attachment
-      for (const attachment of results) {
+      // Build a lookup from partId to source attachment for audit enrichment
+      const sourceByPartId = new Map(
+        input.attachments.map(a => [a.partId, a]),
+      )
+
+      for (const result of results) {
+        const source = sourceByPartId.get(result.partId)
         auditService.recordCertAttachment({
           userId: input.userId,
-          partId: attachment.partId,
+          partId: result.partId,
           certId: input.certId,
-          stepId: attachment.stepId,
+          stepId: result.stepId,
+          jobId: source?.jobId,
+          pathId: source?.pathId,
         })
       }
 

--- a/server/services/certService.ts
+++ b/server/services/certService.ts
@@ -1,15 +1,31 @@
 import type { CertRepository } from '../repositories/interfaces/certRepository'
+import type { PartRepository } from '../repositories/interfaces/partRepository'
+import type { PathRepository } from '../repositories/interfaces/pathRepository'
 import type { Certificate, CertAttachment } from '../types/domain'
 import type { CreateCertInput, BatchAttachCertInput } from '../types/api'
 import type { AuditService } from '../services/auditService'
 import { assertOneOf, assertNonEmpty } from '../utils/validation'
-import { NotFoundError } from '../utils/errors'
+import { NotFoundError, ValidationError } from '../utils/errors'
 import { generateId } from '../utils/idGenerator'
 
 export function createCertService(
-  repos: { certs: CertRepository },
+  repos: { certs: CertRepository, parts: PartRepository, paths: PathRepository },
   auditService: AuditService,
 ) {
+  /**
+   * Resolve a part's current step ID. Throws if the part is already completed.
+   */
+  function resolveCurrentStepId(partId: string): { stepId: string, jobId: string, pathId: string } {
+    const part = repos.parts.getById(partId)
+    if (!part) {
+      throw new NotFoundError('Part', partId)
+    }
+    if (part.currentStepId === null) {
+      throw new ValidationError(`Part ${partId} is already completed, cannot attach cert`)
+    }
+    return { stepId: part.currentStepId, jobId: part.jobId, pathId: part.pathId }
+  }
+
   return {
     createCert(input: CreateCertInput): Certificate {
       assertOneOf(input.type, ['material', 'process'] as const, 'type')
@@ -87,43 +103,32 @@ export function createCertService(
       })
     },
 
-    /** @deprecated Use `batchAttachCertWithSteps` instead — this method sets stepId to empty string which violates the FK constraint. */
     batchAttachCert(input: BatchAttachCertInput): CertAttachment[] {
-      return this.batchAttachCertWithSteps({
-        certId: input.certId,
-        attachments: input.partIds.map(partId => ({ partId, stepId: '' })),
-        userId: input.userId,
-      })
-    },
-
-    batchAttachCertWithSteps(input: {
-      certId: string
-      attachments: readonly { partId: string, stepId: string, jobId?: string, pathId?: string }[]
-      userId: string
-    }): CertAttachment[] {
       const cert = repos.certs.getById(input.certId)
       if (!cert) {
         throw new NotFoundError('Certificate', input.certId)
       }
 
+      // Resolve each part's current step — same logic as single attach
+      const resolved = input.partIds.map((partId) => {
+        const ctx = resolveCurrentStepId(partId)
+        return { partId, ...ctx }
+      })
+
       const now = new Date().toISOString()
-      const rows: CertAttachment[] = input.attachments.map(a => ({
-        partId: a.partId,
+      const rows: CertAttachment[] = resolved.map(r => ({
+        partId: r.partId,
         certId: input.certId,
-        stepId: a.stepId,
+        stepId: r.stepId,
         attachedAt: now,
         attachedBy: input.userId,
       }))
 
       const results = repos.certs.batchAttach(rows)
 
-      // Build a lookup from partId to source attachment for audit enrichment
-      const sourceByPartId = new Map(
-        input.attachments.map(a => [a.partId, a]),
-      )
-
+      const resolvedByPartId = new Map(resolved.map(r => [r.partId, r]))
       for (const result of results) {
-        const source = sourceByPartId.get(result.partId)
+        const source = resolvedByPartId.get(result.partId)
         auditService.recordCertAttachment({
           userId: input.userId,
           partId: result.partId,

--- a/server/services/templateService.ts
+++ b/server/services/templateService.ts
@@ -1,6 +1,6 @@
 import type { TemplateRepository } from '../repositories/interfaces/templateRepository'
 import type { PathRepository } from '../repositories/interfaces/pathRepository'
-import type { TemplateRoute, TemplateStep, Path, ProcessStep } from '../types/domain'
+import type { TemplateRoute, TemplateStep, Path, ProcessStep, DependencyType } from '../types/domain'
 import type { CreateTemplateInput, ApplyTemplateInput } from '../types/api'
 import { generateId } from '../utils/idGenerator'
 import { assertNonEmpty, assertNonEmptyArray } from '../utils/validation'
@@ -82,7 +82,7 @@ export function createTemplateService(repos: {
       return repos.paths.create(path)
     },
 
-    updateTemplate(id: string, input: { name?: string, steps?: { name: string, location?: string, optional?: boolean, dependencyType?: 'physical' | 'preferred' | 'completion_gate' }[] }): TemplateRoute {
+    updateTemplate(id: string, input: { name?: string, steps?: { name: string, location?: string, optional?: boolean, dependencyType?: DependencyType }[] }): TemplateRoute {
       const existing = repos.templates.getById(id)
       if (!existing) {
         throw new NotFoundError('TemplateRoute', id)

--- a/server/types/api.ts
+++ b/server/types/api.ts
@@ -5,7 +5,7 @@
  * API routes parse incoming data into these types before delegating to services.
  */
 
-import type { AdvancementMode, ScrapReason } from './domain'
+import type { AdvancementMode, DependencyType, ScrapReason } from './domain'
 
 // ---- Job ----
 
@@ -32,14 +32,14 @@ export interface CreatePathInput {
   name: string
   goalQuantity: number
   advancementMode?: AdvancementMode
-  steps: { name: string, location?: string, assignedTo?: string | null, optional?: boolean, dependencyType?: 'physical' | 'preferred' | 'completion_gate' }[]
+  steps: { name: string, location?: string, assignedTo?: string | null, optional?: boolean, dependencyType?: DependencyType }[]
 }
 
 export interface UpdatePathInput {
   name?: string
   goalQuantity?: number
   advancementMode?: AdvancementMode
-  steps?: { id?: string, name: string, location?: string, optional?: boolean, dependencyType?: 'physical' | 'preferred' | 'completion_gate' }[]
+  steps?: { id?: string, name: string, location?: string, optional?: boolean, dependencyType?: DependencyType }[]
 }
 
 export interface BatchPathOperationsInput {

--- a/server/types/domain.ts
+++ b/server/types/domain.ts
@@ -24,7 +24,8 @@ export interface Job {
 
 // ---- Path ----
 
-export type AdvancementMode = 'strict' | 'flexible' | 'per_step'
+export const ADVANCEMENT_MODES = ['strict', 'flexible', 'per_step'] as const
+export type AdvancementMode = typeof ADVANCEMENT_MODES[number]
 
 export interface Path {
   id: string
@@ -39,6 +40,9 @@ export interface Path {
 
 // ---- Process Step ----
 
+export const DEPENDENCY_TYPES = ['physical', 'preferred', 'completion_gate'] as const
+export type DependencyType = typeof DEPENDENCY_TYPES[number]
+
 export interface ProcessStep {
   id: string
   name: string
@@ -46,7 +50,7 @@ export interface ProcessStep {
   location?: string
   assignedTo?: string
   optional: boolean
-  dependencyType: 'physical' | 'preferred' | 'completion_gate'
+  dependencyType: DependencyType
   removedAt?: string // soft-delete timestamp; null/undefined = active
   completedCount: number // write-time counter: parts that have completed this step
 }
@@ -59,12 +63,13 @@ export interface StepInput {
   location?: string
   assignedTo?: string | null // undefined = no change/preserve, null = clear assignment
   optional?: boolean
-  dependencyType?: 'physical' | 'preferred' | 'completion_gate'
+  dependencyType?: DependencyType
 }
 
 // ---- Part (formerly Serial Number) ----
 
-export type ScrapReason = 'out_of_tolerance' | 'process_defect' | 'damaged' | 'operator_error' | 'other'
+export const SCRAP_REASONS = ['out_of_tolerance', 'process_defect', 'damaged', 'operator_error', 'other'] as const
+export type ScrapReason = typeof SCRAP_REASONS[number]
 
 export interface Part {
   id: string
@@ -90,9 +95,12 @@ export type SerialNumber = Part
 
 // ---- Certificate ----
 
+export const CERT_TYPES = ['material', 'process'] as const
+export type CertType = typeof CERT_TYPES[number]
+
 export interface Certificate {
   id: string
-  type: 'material' | 'process'
+  type: CertType
   name: string
   metadata?: Record<string, unknown>
   createdAt: string
@@ -124,7 +132,7 @@ export interface TemplateStep {
   order: number
   location?: string
   optional: boolean
-  dependencyType: 'physical' | 'preferred' | 'completion_gate'
+  dependencyType: DependencyType
 }
 
 // ---- BOM (Bill of Materials) ----

--- a/server/utils/services.ts
+++ b/server/utils/services.ts
@@ -120,7 +120,7 @@ export function getServices(): ServiceSet {
       partIdGenerator,
       lifecycleService,
     )
-    const certService = createCertService({ certs: repos.certs }, auditService)
+    const certService = createCertService({ certs: repos.certs, parts: repos.parts, paths: repos.paths }, auditService)
     const noteService = createNoteService({ notes: repos.notes }, auditService)
 
     // Settings service depends on runtimeConfig

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -104,7 +104,7 @@ export function createTestContext() {
     partIdGenerator,
     lifecycleService,
   )
-  const certService = createCertService({ certs: repos.certs }, auditService)
+  const certService = createCertService({ certs: repos.certs, parts: repos.parts, paths: repos.paths }, auditService)
   const templateService = createTemplateService({ templates: repos.templates, paths: repos.paths })
   const bomService = createBomService(
     { bom: repos.bom, parts: repos.parts, jobs: repos.jobs, bomVersions: repos.bomVersions },

--- a/tests/properties/auditTrail.property.test.ts
+++ b/tests/properties/auditTrail.property.test.ts
@@ -49,7 +49,7 @@ function setupServices(db: Database.Database) {
     auditService,
     partIdGenerator,
   )
-  const certService = createCertService({ certs: repos.certs }, auditService)
+  const certService = createCertService({ certs: repos.certs, parts: repos.parts, paths: repos.paths }, auditService)
 
   return { jobService, pathService, partService, certService, auditService, repos }
 }

--- a/tests/properties/batchIdempotence.property.test.ts
+++ b/tests/properties/batchIdempotence.property.test.ts
@@ -51,7 +51,7 @@ function setupServices(db: Database.Database) {
     auditService,
     partIdGenerator,
   )
-  const certService = createCertService({ certs: repos.certs }, auditService)
+  const certService = createCertService({ certs: repos.certs, parts: repos.parts, paths: repos.paths }, auditService)
 
   return { jobService, pathService, partService, certService, repos }
 }

--- a/tests/properties/inputValidation.property.test.ts
+++ b/tests/properties/inputValidation.property.test.ts
@@ -50,7 +50,7 @@ function setupServices(db: Database.Database) {
     auditService,
     partIdGenerator,
   )
-  const certService = createCertService({ certs: repos.certs }, auditService)
+  const certService = createCertService({ certs: repos.certs, parts: repos.parts, paths: repos.paths }, auditService)
 
   return { jobService, pathService, partService, certService, repos }
 }

--- a/tests/unit/schemas/schemaServiceContract.test.ts
+++ b/tests/unit/schemas/schemaServiceContract.test.ts
@@ -197,7 +197,7 @@ describe('Cert schemas → certService', () => {
     expect(cert.metadata).toEqual({ temperature: 1200, duration: '2h' })
   })
 
-  it('batchAttachCertSchema output is accepted by certService.batchAttachCertWithSteps', () => {
+  it('batchAttachCertSchema output is accepted by certService.batchAttachCert', () => {
     const cert = ctx.certService.createCert({ type: 'material', name: 'Batch Cert' })
     const job = ctx.jobService.createJob({ name: 'Cert Job', goalQuantity: 10 })
     const path = ctx.pathService.createPath({
@@ -214,17 +214,8 @@ describe('Cert schemas → certService', () => {
       certId: cert.id,
       partIds: parts.map(p => p.id),
     })
-    // Route handler resolves each part's current step, then calls batchAttachCertWithSteps
-    const attachments = ctx.certService.batchAttachCertWithSteps({
-      certId: body.certId,
-      attachments: parts.map(p => ({
-        partId: p.id,
-        stepId: p.currentStepId!,
-        jobId: p.jobId,
-        pathId: p.pathId,
-      })),
-      userId: 'user_1',
-    })
+    // Service now resolves step IDs internally — no route-level workaround needed
+    const attachments = ctx.certService.batchAttachCert({ ...body, userId: 'user_1' })
     expect(attachments).toHaveLength(2)
     expect(attachments[0].stepId).toBe(path.steps[0].id)
   })

--- a/tests/unit/schemas/schemaServiceContract.test.ts
+++ b/tests/unit/schemas/schemaServiceContract.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Schema ↔ Service contract tests.
+ *
+ * Each test parses a valid payload through the Zod schema used by an API route,
+ * then passes the result to the corresponding service method. This catches
+ * mismatches where a schema requires/omits fields the service doesn't expect
+ * (like the stepId bug in batchAttachCertSchema).
+ *
+ * Uses real service instances backed by in-memory SQLite — no mocking.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { createTestContext, type TestContext } from '../../integration/helpers'
+import { createJobSchema, updateJobSchema, updatePrioritiesSchema } from '~/server/schemas/jobSchemas'
+import {
+  createPartsSchema,
+  scrapPartSchema,
+  forceCompleteSchema,
+  advanceToStepSchema,
+  attachCertSchema,
+} from '~/server/schemas/partSchemas'
+import { createCertSchema, batchAttachCertSchema } from '~/server/schemas/certSchemas'
+import {
+  createTemplateSchema,
+  updateTemplateSchema,
+  applyTemplateSchema,
+} from '~/server/schemas/templateSchemas'
+import { createUserSchema, updateUserSchema } from '~/server/schemas/userSchemas'
+import { updateSettingsSchema } from '~/server/schemas/settingsSchemas'
+import { createUserService } from '~/server/services/userService'
+import { createSettingsService } from '~/server/services/settingsService'
+import { SQLiteSettingsRepository } from '~/server/repositories/sqlite/settingsRepository'
+
+let ctx: TestContext
+
+beforeAll(() => {
+  ctx = createTestContext()
+})
+afterAll(() => {
+  ctx.cleanup()
+})
+
+/**
+ * Helper: parse payload through schema, assert success, return typed data.
+ */
+function parse<T>(schema: { safeParse: (v: unknown) => { success: boolean, data?: T, error?: unknown } }, payload: unknown): T {
+  const result = schema.safeParse(payload)
+  expect(result.success, `Schema parse failed: ${JSON.stringify(result.error)}`).toBe(true)
+  return result.data as T
+}
+
+// ── Jobs ──
+
+describe('Job schemas → jobService', () => {
+  it('createJobSchema output is accepted by jobService.createJob', () => {
+    const body = parse(createJobSchema, { name: 'Test Job', goalQuantity: 10 })
+    const job = ctx.jobService.createJob(body)
+    expect(job.name).toBe('Test Job')
+    expect(job.goalQuantity).toBe(10)
+  })
+
+  it('createJobSchema with Jira fields is accepted', () => {
+    const body = parse(createJobSchema, {
+      name: 'Jira Job',
+      goalQuantity: 5,
+      jiraTicketKey: 'PI-123',
+      jiraTicketSummary: 'Summary',
+      jiraPartNumber: 'PN-001',
+      jiraPriority: 'High',
+      jiraEpicLink: 'PI-1',
+      jiraLabels: ['urgent', 'machining'],
+    })
+    const job = ctx.jobService.createJob(body)
+    expect(job.jiraTicketKey).toBe('PI-123')
+  })
+
+  it('updateJobSchema output is accepted by jobService.updateJob', () => {
+    const job = ctx.jobService.createJob({ name: 'Original', goalQuantity: 5 })
+    const body = parse(updateJobSchema, { name: 'Updated', goalQuantity: 20 })
+    const updated = ctx.jobService.updateJob(job.id, body)
+    expect(updated.name).toBe('Updated')
+    expect(updated.goalQuantity).toBe(20)
+  })
+
+  it('updatePrioritiesSchema output is accepted by jobService.updatePriorities', () => {
+    // Create a fresh context so we control the exact job count
+    const freshCtx = createTestContext()
+    const a = freshCtx.jobService.createJob({ name: 'A', goalQuantity: 10 })
+    const b = freshCtx.jobService.createJob({ name: 'B', goalQuantity: 10 })
+    const body = parse(updatePrioritiesSchema, {
+      priorities: [
+        { jobId: a.id, priority: 1 },
+        { jobId: b.id, priority: 2 },
+      ],
+    })
+    const result = freshCtx.jobService.updatePriorities(body)
+    expect(result.length).toBeGreaterThanOrEqual(2)
+    freshCtx.cleanup()
+  })
+})
+
+// ── Parts ──
+
+describe('Part schemas → partService / lifecycleService', () => {
+  let jobId: string
+  let pathId: string
+  let _stepId: string
+
+  beforeAll(() => {
+    const job = ctx.jobService.createJob({ name: 'Part Test Job', goalQuantity: 100 })
+    jobId = job.id
+    const path = ctx.pathService.createPath({
+      jobId,
+      name: 'Route A',
+      goalQuantity: 100,
+      steps: [{ name: 'Step 1' }, { name: 'Step 2' }],
+    })
+    pathId = path.id
+    _stepId = path.steps[0].id
+  })
+
+  it('createPartsSchema output is accepted by partService.batchCreateParts', () => {
+    const body = parse(createPartsSchema, { jobId, pathId, quantity: 3 })
+    const parts = ctx.partService.batchCreateParts(body, 'user_1')
+    expect(parts).toHaveLength(3)
+  })
+
+  it('createPartsSchema with certId is accepted', () => {
+    const cert = ctx.certService.createCert({ type: 'material', name: 'Test Cert' })
+    const body = parse(createPartsSchema, { jobId, pathId, quantity: 1, certId: cert.id })
+    const parts = ctx.partService.batchCreateParts(body, 'user_1')
+    expect(parts).toHaveLength(1)
+  })
+
+  it('scrapPartSchema output is accepted by lifecycleService.scrapPart', () => {
+    const [part] = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 1 }, 'user_1')
+    const body = parse(scrapPartSchema, { reason: 'damaged' })
+    const scrapped = ctx.lifecycleService.scrapPart(part.id, { ...body, userId: 'user_1' })
+    expect(scrapped.status).toBe('scrapped')
+  })
+
+  it('scrapPartSchema with explanation is accepted', () => {
+    const [part] = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 1 }, 'user_1')
+    const body = parse(scrapPartSchema, { reason: 'other', explanation: 'Dropped on floor' })
+    const scrapped = ctx.lifecycleService.scrapPart(part.id, { ...body, userId: 'user_1' })
+    expect(scrapped.scrapReason).toBe('other')
+  })
+
+  it('forceCompleteSchema output is accepted by lifecycleService.forceComplete', () => {
+    const [part] = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 1 }, 'user_1')
+    const body = parse(forceCompleteSchema, { reason: 'Customer approved' })
+    const completed = ctx.lifecycleService.forceComplete(part.id, { ...body, userId: 'user_1' })
+    expect(completed.status).toBe('completed')
+  })
+
+  it('forceCompleteSchema with empty body is accepted', () => {
+    const [part] = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 1 }, 'user_1')
+    const body = parse(forceCompleteSchema, {})
+    const completed = ctx.lifecycleService.forceComplete(part.id, { ...body, userId: 'user_1' })
+    expect(completed.forceCompleted).toBe(true)
+  })
+
+  it('advanceToStepSchema output is accepted by lifecycleService.advanceToStep', () => {
+    const [part] = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 1 }, 'user_1')
+    const path = ctx.pathService.getPath(pathId)
+    const body = parse(advanceToStepSchema, { targetStepId: path.steps[1].id })
+    // The schema output + userId is what the route passes to the service
+    // Part starts at step[0], advancing to step[1] should work
+    const result = ctx.lifecycleService.advanceToStep(part.id, { ...body, userId: 'user_1' })
+    expect(result.serial).toBeDefined()
+  })
+
+  it('attachCertSchema output is accepted (certId field matches service expectation)', () => {
+    const body = parse(attachCertSchema, { certId: 'cert_123' })
+    expect(body.certId).toBe('cert_123')
+    // The route handler uses body.certId to call certService.attachCertToSerial
+    // We just verify the schema output shape is correct
+  })
+})
+
+// ── Certificates ──
+
+describe('Cert schemas → certService', () => {
+  it('createCertSchema output is accepted by certService.createCert', () => {
+    const body = parse(createCertSchema, { type: 'material', name: 'Steel Cert' })
+    const cert = ctx.certService.createCert(body)
+    expect(cert.name).toBe('Steel Cert')
+    expect(cert.type).toBe('material')
+  })
+
+  it('createCertSchema with metadata is accepted', () => {
+    const body = parse(createCertSchema, {
+      type: 'process',
+      name: 'Heat Treat',
+      metadata: { temperature: 1200, duration: '2h' },
+    })
+    const cert = ctx.certService.createCert(body)
+    expect(cert.metadata).toEqual({ temperature: 1200, duration: '2h' })
+  })
+
+  it('batchAttachCertSchema output is accepted by certService.batchAttachCert', () => {
+    // Verify schema output shape matches BatchAttachCertInput (minus userId which route adds)
+    const body = parse(batchAttachCertSchema, {
+      certId: 'cert_123',
+      partIds: ['part_1', 'part_2'],
+    })
+    // Schema output must have certId and partIds — the route adds userId
+    expect(body).toEqual({ certId: 'cert_123', partIds: ['part_1', 'part_2'] })
+    // Verify the spread pattern used in the route handler produces a valid service input
+    const serviceInput = { ...body, userId: 'user_1' }
+    expect(serviceInput).toHaveProperty('certId')
+    expect(serviceInput).toHaveProperty('partIds')
+    expect(serviceInput).toHaveProperty('userId')
+  })
+})
+
+// ── Templates ──
+
+describe('Template schemas → templateService', () => {
+  it('createTemplateSchema output is accepted by templateService.createTemplate', () => {
+    const body = parse(createTemplateSchema, {
+      name: 'Standard Route',
+      steps: [{ name: 'Machining' }, { name: 'Inspection', location: 'QC Lab' }],
+    })
+    const tmpl = ctx.templateService.createTemplate(body)
+    expect(tmpl.name).toBe('Standard Route')
+    expect(tmpl.steps).toHaveLength(2)
+  })
+
+  it('updateTemplateSchema output is accepted by templateService.updateTemplate', () => {
+    const tmpl = ctx.templateService.createTemplate({
+      name: 'Original',
+      steps: [{ name: 'S1' }],
+    })
+    const body = parse(updateTemplateSchema, {
+      name: 'Updated',
+      steps: [{ name: 'S1' }, { name: 'S2', optional: true, dependencyType: 'preferred' }],
+    })
+    const updated = ctx.templateService.updateTemplate(tmpl.id, body)
+    expect(updated.name).toBe('Updated')
+    expect(updated.steps).toHaveLength(2)
+  })
+
+  it('applyTemplateSchema output is accepted by templateService.applyTemplate', () => {
+    const tmpl = ctx.templateService.createTemplate({
+      name: 'Apply Test',
+      steps: [{ name: 'S1' }],
+    })
+    const job = ctx.jobService.createJob({ name: 'Apply Job', goalQuantity: 10 })
+    const body = parse(applyTemplateSchema, {
+      jobId: job.id,
+      goalQuantity: 10,
+      pathName: 'Custom Path',
+    })
+    const path = ctx.templateService.applyTemplate(tmpl.id, body)
+    expect(path.name).toBe('Custom Path')
+  })
+})
+
+// ── Users ──
+
+describe('User schemas → userService', () => {
+  it('createUserSchema output is accepted by userService.createUser', () => {
+    const body = parse(createUserSchema, {
+      username: 'jdoe',
+      displayName: 'John Doe',
+      isAdmin: false,
+    })
+    const userService = createUserService({ users: ctx.repos.users })
+    const user = userService.createUser(body)
+    expect(user.username).toBe('jdoe')
+    expect(user.displayName).toBe('John Doe')
+  })
+
+  it('createUserSchema with isAdmin=true is accepted', () => {
+    const body = parse(createUserSchema, {
+      username: 'admin1',
+      displayName: 'Admin User',
+      isAdmin: true,
+    })
+    const userService = createUserService({ users: ctx.repos.users })
+    const user = userService.createUser(body)
+    expect(user.isAdmin).toBe(true)
+  })
+
+  it('updateUserSchema output is accepted by userService.updateUser', () => {
+    const userService = createUserService({ users: ctx.repos.users })
+    const user = userService.createUser({ username: 'update_test', displayName: 'Before' })
+    const body = parse(updateUserSchema, { displayName: 'After', isAdmin: true })
+    const updated = userService.updateUser(user.id, body)
+    expect(updated.displayName).toBe('After')
+    expect(updated.isAdmin).toBe(true)
+  })
+})
+
+// ── Settings ──
+
+describe('Settings schema → settingsService', () => {
+  it('updateSettingsSchema output is accepted by settingsService.updateSettings', () => {
+    const settingsRepo = new SQLiteSettingsRepository(ctx.db)
+    const settingsService = createSettingsService(
+      { settings: settingsRepo },
+      { jiraBaseUrl: '', jiraProjectKey: 'PI', jiraUsername: '', jiraApiToken: '' },
+    )
+    const body = parse(updateSettingsSchema, {
+      pageToggles: { jobs: false, audit: true },
+    })
+    const result = settingsService.updateSettings(body)
+    expect(result.pageToggles.jobs).toBe(false)
+    expect(result.pageToggles.audit).toBe(true)
+  })
+
+  it('updateSettingsSchema with jiraConnection is accepted', () => {
+    const settingsRepo = new SQLiteSettingsRepository(ctx.db)
+    const settingsService = createSettingsService(
+      { settings: settingsRepo },
+      { jiraBaseUrl: '', jiraProjectKey: 'PI', jiraUsername: '', jiraApiToken: '' },
+    )
+    const body = parse(updateSettingsSchema, {
+      jiraConnection: { enabled: true, baseUrl: 'https://jira.example.com' },
+    })
+    const result = settingsService.updateSettings(body)
+    expect(result.jiraConnection.enabled).toBe(true)
+  })
+})

--- a/tests/unit/schemas/schemaServiceContract.test.ts
+++ b/tests/unit/schemas/schemaServiceContract.test.ts
@@ -17,6 +17,11 @@ import {
   forceCompleteSchema,
   advanceToStepSchema,
   attachCertSchema,
+  batchAdvanceSchema,
+  batchAdvanceToSchema,
+  batchStepStatusesSchema,
+  createOverrideSchema,
+  waiveStepSchema,
 } from '~/server/schemas/partSchemas'
 import { createCertSchema, batchAttachCertSchema } from '~/server/schemas/certSchemas'
 import {
@@ -26,6 +31,21 @@ import {
 } from '~/server/schemas/templateSchemas'
 import { createUserSchema, updateUserSchema } from '~/server/schemas/userSchemas'
 import { updateSettingsSchema } from '~/server/schemas/settingsSchemas'
+import {
+  createPathSchema,
+  updatePathSchema,
+  updateAdvancementModeSchema,
+  batchDistributionsSchema,
+  batchPathOperationsSchema,
+  assignStepSchema,
+  updateStepConfigSchema,
+} from '~/server/schemas/pathSchemas'
+import { createBomSchema, updateBomSchema, editBomSchema } from '~/server/schemas/bomSchemas'
+import { loginSchema, setupPinSchema, resetPinSchema } from '~/server/schemas/authSchemas'
+import { pushJiraCommentSchema, linkJiraTicketSchema, jiraPushSchema } from '~/server/schemas/jiraSchemas'
+import { createTagSchema, updateTagSchema, setJobTagsSchema } from '~/server/schemas/tagSchemas'
+import { createNoteSchema } from '~/server/schemas/noteSchemas'
+import { addLibraryEntrySchema } from '~/server/schemas/librarySchemas'
 import { createUserService } from '~/server/services/userService'
 import { createSettingsService } from '~/server/services/settingsService'
 import { SQLiteSettingsRepository } from '~/server/repositories/sqlite/settingsRepository'
@@ -82,7 +102,6 @@ describe('Job schemas → jobService', () => {
   })
 
   it('updatePrioritiesSchema output is accepted by jobService.updatePriorities', () => {
-    // Create a fresh context so we control the exact job count
     const freshCtx = createTestContext()
     const a = freshCtx.jobService.createJob({ name: 'A', goalQuantity: 10 })
     const b = freshCtx.jobService.createJob({ name: 'B', goalQuantity: 10 })
@@ -103,7 +122,6 @@ describe('Job schemas → jobService', () => {
 describe('Part schemas → partService / lifecycleService', () => {
   let jobId: string
   let pathId: string
-  let _stepId: string
 
   beforeAll(() => {
     const job = ctx.jobService.createJob({ name: 'Part Test Job', goalQuantity: 100 })
@@ -112,10 +130,9 @@ describe('Part schemas → partService / lifecycleService', () => {
       jobId,
       name: 'Route A',
       goalQuantity: 100,
-      steps: [{ name: 'Step 1' }, { name: 'Step 2' }],
+      steps: [{ name: 'Step 1' }, { name: 'Step 2' }, { name: 'Step 3' }],
     })
     pathId = path.id
-    _stepId = path.steps[0].id
   })
 
   it('createPartsSchema output is accepted by partService.batchCreateParts', () => {
@@ -163,17 +180,109 @@ describe('Part schemas → partService / lifecycleService', () => {
     const [part] = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 1 }, 'user_1')
     const path = ctx.pathService.getPath(pathId)
     const body = parse(advanceToStepSchema, { targetStepId: path.steps[1].id })
-    // The schema output + userId is what the route passes to the service
-    // Part starts at step[0], advancing to step[1] should work
     const result = ctx.lifecycleService.advanceToStep(part.id, { ...body, userId: 'user_1' })
     expect(result.serial).toBeDefined()
   })
 
-  it('attachCertSchema output is accepted (certId field matches service expectation)', () => {
+  it('attachCertSchema output shape matches route usage', () => {
     const body = parse(attachCertSchema, { certId: 'cert_123' })
     expect(body.certId).toBe('cert_123')
-    // The route handler uses body.certId to call certService.attachCertToSerial
-    // We just verify the schema output shape is correct
+  })
+
+  it('batchAdvanceSchema output is accepted by partService.batchAdvanceParts', () => {
+    const parts = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 2 }, 'user_1')
+    const body = parse(batchAdvanceSchema, { partIds: parts.map(p => p.id) })
+    const results = ctx.partService.batchAdvanceParts(body.partIds, 'user_1')
+    expect(results.advanced).toBe(2)
+  })
+
+  it('batchAdvanceToSchema output is accepted by lifecycleService.advanceToStep (per-part loop)', () => {
+    const parts = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 2 }, 'user_1')
+    const path = ctx.pathService.getPath(pathId)
+    const body = parse(batchAdvanceToSchema, {
+      partIds: parts.map(p => p.id),
+      targetStepId: path.steps[1].id,
+    })
+    // Route loops over partIds calling lifecycleService.advanceToStep per part
+    for (const partId of body.partIds) {
+      const result = ctx.lifecycleService.advanceToStep(partId, {
+        targetStepId: body.targetStepId,
+        skip: body.skip,
+        userId: 'user_1',
+      })
+      expect(result.serial).toBeDefined()
+    }
+  })
+
+  it('batchStepStatusesSchema output is accepted by lifecycleService.getStepStatusViews', () => {
+    const parts = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 2 }, 'user_1')
+    const body = parse(batchStepStatusesSchema, { partIds: parts.map(p => p.id) })
+    // Route loops over partIds calling lifecycleService.getStepStatusViews per part
+    for (const partId of body.partIds) {
+      const views = ctx.lifecycleService.getStepStatusViews(partId)
+      expect(views.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('createOverrideSchema output is accepted by lifecycleService.createStepOverride', () => {
+    const parts = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 2 }, 'user_1')
+    const path = ctx.pathService.getPath(pathId)
+    const body = parse(createOverrideSchema, {
+      partIds: parts.map(p => p.id),
+      stepId: path.steps[1].id,
+      reason: 'Customer waiver',
+    })
+    // Route uses: body.partIds || body.serialIds!
+    const overrides = ctx.lifecycleService.createStepOverride(
+      body.partIds || body.serialIds!,
+      body.stepId,
+      body.reason,
+      'user_1',
+    )
+    expect(overrides.length).toBeGreaterThan(0)
+  })
+
+  it('createOverrideSchema with legacy serialIds is accepted', () => {
+    const parts = ctx.partService.batchCreateParts({ jobId, pathId, quantity: 1 }, 'user_1')
+    const path = ctx.pathService.getPath(pathId)
+    const body = parse(createOverrideSchema, {
+      serialIds: parts.map(p => p.id),
+      stepId: path.steps[2].id,
+      reason: 'Legacy compat',
+    })
+    const overrides = ctx.lifecycleService.createStepOverride(
+      body.partIds || body.serialIds!,
+      body.stepId,
+      body.reason,
+      'user_1',
+    )
+    expect(overrides.length).toBe(1)
+  })
+
+  it('waiveStepSchema output is accepted by lifecycleService.waiveStep', () => {
+    // Need a flexible path so we can skip ahead to create a deferred step
+    const flexPath = ctx.pathService.createPath({
+      jobId,
+      name: 'Flex Route',
+      goalQuantity: 10,
+      advancementMode: 'flexible',
+      steps: [{ name: 'F1' }, { name: 'F2' }, { name: 'F3' }],
+    })
+    const [part] = ctx.partService.batchCreateParts({ jobId, pathId: flexPath.id, quantity: 1 }, 'user_1')
+    // Advance to step 3, skipping step 2 — step 2 becomes deferred (required)
+    ctx.lifecycleService.advanceToStep(part.id, {
+      targetStepId: flexPath.steps[2].id,
+      skip: true,
+      userId: 'user_1',
+    })
+    // Step 1 (F2) is now deferred — waive it
+    const body = parse(waiveStepSchema, { reason: 'Approved by QA' })
+    // Route passes: { ...body, approverId: userId }
+    const result = ctx.lifecycleService.waiveStep(part.id, flexPath.steps[1].id, {
+      ...body,
+      approverId: 'user_1',
+    })
+    expect(result.status).toBe('waived')
   })
 })
 
@@ -214,10 +323,158 @@ describe('Cert schemas → certService', () => {
       certId: cert.id,
       partIds: parts.map(p => p.id),
     })
-    // Service now resolves step IDs internally — no route-level workaround needed
     const attachments = ctx.certService.batchAttachCert({ ...body, userId: 'user_1' })
     expect(attachments).toHaveLength(2)
     expect(attachments[0].stepId).toBe(path.steps[0].id)
+  })
+})
+
+// ── Paths ──
+
+describe('Path schemas → pathService', () => {
+  let jobId: string
+
+  beforeAll(() => {
+    const job = ctx.jobService.createJob({ name: 'Path Test Job', goalQuantity: 50 })
+    jobId = job.id
+  })
+
+  it('createPathSchema output is accepted by pathService.createPath', () => {
+    const body = parse(createPathSchema, {
+      jobId,
+      name: 'Main Route',
+      goalQuantity: 50,
+      steps: [{ name: 'Cut' }, { name: 'Weld', location: 'Bay 3' }],
+    })
+    const path = ctx.pathService.createPath(body)
+    expect(path.name).toBe('Main Route')
+    expect(path.steps).toHaveLength(2)
+  })
+
+  it('createPathSchema with all step options is accepted', () => {
+    const body = parse(createPathSchema, {
+      jobId,
+      name: 'Full Options',
+      goalQuantity: 10,
+      advancementMode: 'flexible',
+      steps: [{
+        name: 'Inspect',
+        location: 'QC Lab',
+        optional: true,
+        dependencyType: 'completion_gate',
+      }],
+    })
+    const path = ctx.pathService.createPath(body)
+    expect(path.advancementMode).toBe('flexible')
+    expect(path.steps[0].optional).toBe(true)
+    expect(path.steps[0].dependencyType).toBe('completion_gate')
+  })
+
+  it('updatePathSchema output is accepted by pathService.updatePath', () => {
+    const path = ctx.pathService.createPath({
+      jobId,
+      name: 'Before',
+      goalQuantity: 10,
+      steps: [{ name: 'S1' }],
+    })
+    const body = parse(updatePathSchema, { name: 'After', goalQuantity: 20 })
+    const updated = ctx.pathService.updatePath(path.id, body)
+    expect(updated.name).toBe('After')
+    expect(updated.goalQuantity).toBe(20)
+  })
+
+  it('updateAdvancementModeSchema output is accepted by pathService.updatePath', () => {
+    const path = ctx.pathService.createPath({
+      jobId,
+      name: 'Mode Test',
+      goalQuantity: 10,
+      steps: [{ name: 'S1' }],
+    })
+    const body = parse(updateAdvancementModeSchema, { advancementMode: 'per_step' })
+    // Route calls: pathService.updatePath(id, { advancementMode: body.advancementMode })
+    const updated = ctx.pathService.updatePath(path.id, { advancementMode: body.advancementMode })
+    expect(updated.advancementMode).toBe('per_step')
+  })
+
+  it('batchDistributionsSchema output is accepted by pathService.getStepDistribution', () => {
+    const path = ctx.pathService.createPath({
+      jobId,
+      name: 'Dist Test',
+      goalQuantity: 10,
+      steps: [{ name: 'S1' }],
+    })
+    const body = parse(batchDistributionsSchema, { pathIds: [path.id] })
+    // Route loops over pathIds
+    for (const pathId of body.pathIds) {
+      const dist = ctx.pathService.getStepDistribution(pathId)
+      expect(dist).toBeDefined()
+      const count = ctx.pathService.getPathCompletedCount(pathId)
+      expect(count).toBe(0)
+    }
+  })
+
+  it('assignStepSchema output is accepted by pathService.assignStep', () => {
+    const path = ctx.pathService.createPath({
+      jobId,
+      name: 'Assign Test',
+      goalQuantity: 10,
+      steps: [{ name: 'S1' }],
+    })
+    // Assign null (unassign)
+    const body = parse(assignStepSchema, { userId: null })
+    const step = ctx.pathService.assignStep(path.steps[0].id, body.userId)
+    expect(step.assignedTo).toBeUndefined()
+  })
+
+  it('updateStepConfigSchema output is accepted by pathService.updateStep', () => {
+    const path = ctx.pathService.createPath({
+      jobId,
+      name: 'Config Test',
+      goalQuantity: 10,
+      steps: [{ name: 'S1' }],
+    })
+    const body = parse(updateStepConfigSchema, {
+      optional: true,
+      dependencyType: 'physical',
+      location: 'Bay 5',
+    })
+    // Route builds partial from body fields
+    const update: Record<string, unknown> = {}
+    if (typeof body.optional === 'boolean') update.optional = body.optional
+    if (typeof body.location === 'string') update.location = body.location.trim() || undefined
+    if (body.dependencyType) update.dependencyType = body.dependencyType
+    const step = ctx.pathService.updateStep(path.steps[0].id, update)
+    expect(step.optional).toBe(true)
+    expect(step.dependencyType).toBe('physical')
+  })
+
+  it('batchPathOperationsSchema output is accepted by pathService.batchPathOperations', () => {
+    const freshCtx = createTestContext()
+    const job = freshCtx.jobService.createJob({ name: 'Batch Op Job', goalQuantity: 10 })
+    // Create an admin user for delete operations
+    const admin = freshCtx.repos.users.create({
+      id: 'admin_1',
+      username: 'admin_batch',
+      displayName: 'Admin',
+      isAdmin: true,
+      active: true,
+      pinHash: null,
+      createdAt: new Date().toISOString(),
+    })
+    const body = parse(batchPathOperationsSchema, {
+      create: [{ name: 'New Path', goalQuantity: 10, steps: [{ name: 'S1' }] }],
+      update: [],
+      delete: [],
+    })
+    const result = freshCtx.pathService.batchPathOperations({
+      jobId: job.id,
+      userId: admin.id,
+      create: body.create,
+      update: body.update,
+      delete: body.delete,
+    })
+    expect(result.created).toHaveLength(1)
+    freshCtx.cleanup()
   })
 })
 
@@ -264,24 +521,80 @@ describe('Template schemas → templateService', () => {
   })
 })
 
+// ── BOM ──
+
+describe('BOM schemas → bomService', () => {
+  let jobId: string
+
+  beforeAll(() => {
+    const job = ctx.jobService.createJob({ name: 'BOM Test Job', goalQuantity: 10 })
+    jobId = job.id
+  })
+
+  it('createBomSchema output is accepted by bomService.createBom', () => {
+    const body = parse(createBomSchema, {
+      name: 'Assembly BOM',
+      entries: [{ jobId, requiredQuantity: 5 }],
+    })
+    const bom = ctx.bomService.createBom(body)
+    expect(bom.name).toBe('Assembly BOM')
+    expect(bom.entries).toHaveLength(1)
+    expect(bom.entries[0].requiredQuantity).toBe(5)
+  })
+
+  it('createBomSchema with default requiredQuantity is accepted', () => {
+    const body = parse(createBomSchema, {
+      name: 'Default Qty BOM',
+      entries: [{ jobId }],
+    })
+    const bom = ctx.bomService.createBom(body)
+    // Schema defaults requiredQuantity to 1
+    expect(bom.entries[0].requiredQuantity).toBe(1)
+  })
+
+  it('updateBomSchema output is accepted by bomService.updateBom', () => {
+    const bom = ctx.bomService.createBom({
+      name: 'Before',
+      entries: [{ jobId, requiredQuantity: 1 }],
+    })
+    const body = parse(updateBomSchema, { name: 'After' })
+    const updated = ctx.bomService.updateBom(bom.id, body)
+    expect(updated.name).toBe('After')
+  })
+
+  it('editBomSchema output is accepted by bomService.editBom', () => {
+    const bom = ctx.bomService.createBom({
+      name: 'Edit Test',
+      entries: [{ jobId, requiredQuantity: 1 }],
+    })
+    const body = parse(editBomSchema, {
+      entries: [{ jobId, requiredQuantity: 10 }],
+      changeDescription: 'Increased quantity',
+    })
+    // Route passes: { ...body, userId }
+    const updated = ctx.bomService.editBom(bom.id, { ...body, userId: 'user_1' })
+    expect(updated.entries[0].requiredQuantity).toBe(10)
+  })
+})
+
 // ── Users ──
 
 describe('User schemas → userService', () => {
   it('createUserSchema output is accepted by userService.createUser', () => {
     const body = parse(createUserSchema, {
-      username: 'jdoe',
+      username: 'contract_jdoe',
       displayName: 'John Doe',
       isAdmin: false,
     })
     const userService = createUserService({ users: ctx.repos.users })
     const user = userService.createUser(body)
-    expect(user.username).toBe('jdoe')
+    expect(user.username).toBe('contract_jdoe')
     expect(user.displayName).toBe('John Doe')
   })
 
   it('createUserSchema with isAdmin=true is accepted', () => {
     const body = parse(createUserSchema, {
-      username: 'admin1',
+      username: 'contract_admin1',
       displayName: 'Admin User',
       isAdmin: true,
     })
@@ -292,7 +605,7 @@ describe('User schemas → userService', () => {
 
   it('updateUserSchema output is accepted by userService.updateUser', () => {
     const userService = createUserService({ users: ctx.repos.users })
-    const user = userService.createUser({ username: 'update_test', displayName: 'Before' })
+    const user = userService.createUser({ username: 'contract_update_test', displayName: 'Before' })
     const body = parse(updateUserSchema, { displayName: 'After', isAdmin: true })
     const updated = userService.updateUser(user.id, body)
     expect(updated.displayName).toBe('After')
@@ -328,5 +641,290 @@ describe('Settings schema → settingsService', () => {
     })
     const result = settingsService.updateSettings(body)
     expect(result.jiraConnection.enabled).toBe(true)
+  })
+
+  it('updateSettingsSchema with jiraFieldMappings is accepted', () => {
+    const settingsRepo = new SQLiteSettingsRepository(ctx.db)
+    const settingsService = createSettingsService(
+      { settings: settingsRepo },
+      { jiraBaseUrl: '', jiraProjectKey: 'PI', jiraUsername: '', jiraApiToken: '' },
+    )
+    const body = parse(updateSettingsSchema, {
+      jiraFieldMappings: [{
+        id: 'map_1',
+        jiraFieldId: 'customfield_10900',
+        label: 'Goal Quantity',
+        shopErpField: 'goalQuantity',
+        isDefault: true,
+      }],
+    })
+    const result = settingsService.updateSettings(body)
+    expect(result.jiraFieldMappings).toHaveLength(1)
+  })
+})
+
+// ── Auth ──
+
+describe('Auth schemas → authService', () => {
+  it('loginSchema output shape matches authService.login signature', () => {
+    const body = parse(loginSchema, { username: 'testuser', pin: '1234' })
+    expect(body.username).toBe('testuser')
+    expect(body.pin).toBe('1234')
+    // authService.login(username, pin) — both strings, matches schema output
+  })
+
+  it('setupPinSchema output shape matches authService.setupPin signature', () => {
+    const body = parse(setupPinSchema, { userId: 'user_123', pin: '5678' })
+    expect(body.userId).toBe('user_123')
+    expect(body.pin).toBe('5678')
+    // authService.setupPin(userId, pin) — both strings, matches schema output
+  })
+
+  it('resetPinSchema output shape matches authService.resetPin signature', () => {
+    const body = parse(resetPinSchema, { targetUserId: 'user_456' })
+    expect(body.targetUserId).toBe('user_456')
+    // authService.resetPin(adminUserId, targetUserId) — string, matches schema output
+  })
+
+  it('setupPinSchema → authService.setupPin end-to-end', async () => {
+    const freshCtx = createTestContext()
+    await freshCtx.authService.ensureKeyPair()
+    const user = freshCtx.repos.users.create({
+      id: 'pin_test_user',
+      username: 'pintest',
+      displayName: 'Pin Test',
+      isAdmin: false,
+      active: true,
+      pinHash: null,
+      createdAt: new Date().toISOString(),
+    })
+    const body = parse(setupPinSchema, { userId: user.id, pin: '9999' })
+    const token = await freshCtx.authService.setupPin(body.userId, body.pin)
+    expect(token).toBeTruthy()
+    freshCtx.cleanup()
+  })
+
+  it('loginSchema → authService.login end-to-end', async () => {
+    const freshCtx = createTestContext()
+    await freshCtx.authService.ensureKeyPair()
+    const user = freshCtx.repos.users.create({
+      id: 'login_test_user',
+      username: 'logintest',
+      displayName: 'Login Test',
+      isAdmin: false,
+      active: true,
+      pinHash: null,
+      createdAt: new Date().toISOString(),
+    })
+    await freshCtx.authService.setupPin(user.id, '1234')
+    const body = parse(loginSchema, { username: 'logintest', pin: '1234' })
+    const token = await freshCtx.authService.login(body.username, body.pin)
+    expect(token).toBeTruthy()
+    freshCtx.cleanup()
+  })
+})
+
+// ── Notes ──
+
+describe('Note schemas → noteService', () => {
+  it('createNoteSchema output is accepted by noteService.createNote', () => {
+    const job = ctx.jobService.createJob({ name: 'Note Job', goalQuantity: 10 })
+    const path = ctx.pathService.createPath({
+      jobId: job.id,
+      name: 'Route',
+      goalQuantity: 10,
+      steps: [{ name: 'S1' }],
+    })
+    const parts = ctx.partService.batchCreateParts(
+      { jobId: job.id, pathId: path.id, quantity: 2 },
+      'user_1',
+    )
+    const body = parse(createNoteSchema, {
+      jobId: job.id,
+      pathId: path.id,
+      stepId: path.steps[0].id,
+      partIds: parts.map(p => p.id),
+      text: 'Surface defect observed',
+    })
+    // Route passes: { ...body, userId }
+    const note = ctx.noteService.createNote({ ...body, userId: 'user_1' })
+    expect(note.text).toBe('Surface defect observed')
+    expect(note.partIds).toHaveLength(2)
+  })
+})
+
+// ── Library ──
+
+describe('Library schemas → libraryService', () => {
+  it('addLibraryEntrySchema output is accepted by libraryService.addProcess', () => {
+    const body = parse(addLibraryEntrySchema, { name: 'CNC Milling' })
+    const entry = ctx.libraryService.addProcess(body.name)
+    expect(entry.name).toBe('CNC Milling')
+  })
+
+  it('addLibraryEntrySchema output is accepted by libraryService.addLocation', () => {
+    const body = parse(addLibraryEntrySchema, { name: 'Bay 7' })
+    const entry = ctx.libraryService.addLocation(body.name)
+    expect(entry.name).toBe('Bay 7')
+  })
+})
+
+// ── Tags ──
+
+describe('Tag schemas → tagService / jobService', () => {
+  let adminId: string
+  let tagService: ReturnType<typeof import('~/server/services/tagService').createTagService>
+
+  beforeAll(async () => {
+    const { createTagService } = await import('~/server/services/tagService')
+    const { SQLiteTagRepository } = await import('~/server/repositories/sqlite/tagRepository')
+    const { SQLiteJobTagRepository } = await import('~/server/repositories/sqlite/jobTagRepository')
+    const tagRepo = new SQLiteTagRepository(ctx.db)
+    const jobTagRepo = new SQLiteJobTagRepository(ctx.db)
+    tagService = createTagService(
+      { tags: tagRepo, jobTags: jobTagRepo, jobs: ctx.repos.jobs, users: ctx.repos.users },
+      ctx.auditService,
+    )
+    const admin = ctx.repos.users.create({
+      id: 'tag_admin',
+      username: 'tag_admin',
+      displayName: 'Tag Admin',
+      isAdmin: true,
+      active: true,
+      pinHash: null,
+      createdAt: new Date().toISOString(),
+    })
+    adminId = admin.id
+  })
+
+  it('createTagSchema output is accepted by tagService.createTag', () => {
+    const body = parse(createTagSchema, { name: 'Urgent', color: '#ef4444' })
+    const tag = tagService.createTag(adminId, body)
+    expect(tag.name).toBe('Urgent')
+    expect(tag.color).toBe('#ef4444')
+  })
+
+  it('updateTagSchema output is accepted by tagService.updateTag', () => {
+    const tag = tagService.createTag(adminId, { name: 'Rename Me' })
+    const body = parse(updateTagSchema, { name: 'Renamed', color: '#22c55e' })
+    const updated = tagService.updateTag(adminId, tag.id, body)
+    expect(updated.name).toBe('Renamed')
+    expect(updated.color).toBe('#22c55e')
+  })
+
+  it('setJobTagsSchema output shape matches route usage', () => {
+    const body = parse(setJobTagsSchema, { tagIds: ['tag_1', 'tag_2'] })
+    expect(body.tagIds).toHaveLength(2)
+    // Route calls: jobService.setJobTags(userId, id, body.tagIds)
+    // tagIds is string[] — matches the service signature
+  })
+})
+
+// ── Jira (schema shape validation only — service requires HTTP) ──
+
+describe('Jira schemas → shape validation', () => {
+  it('pushJiraCommentSchema output shape matches route usage', () => {
+    const body = parse(pushJiraCommentSchema, { jobId: 'job_1', noteId: 'note_1' })
+    expect(body.jobId).toBe('job_1')
+    expect(body.noteId).toBe('note_1')
+  })
+
+  it('pushJiraCommentSchema without noteId is accepted', () => {
+    const body = parse(pushJiraCommentSchema, { jobId: 'job_1' })
+    expect(body.jobId).toBe('job_1')
+    expect(body.noteId).toBeUndefined()
+  })
+
+  it('linkJiraTicketSchema output shape matches route usage', () => {
+    const body = parse(linkJiraTicketSchema, {
+      ticketKey: 'PI-42',
+      goalQuantity: 100,
+      templateId: 'tmpl_1',
+    })
+    expect(body.ticketKey).toBe('PI-42')
+    expect(body.goalQuantity).toBe(100)
+    expect(body.templateId).toBe('tmpl_1')
+  })
+
+  it('linkJiraTicketSchema with minimal fields is accepted', () => {
+    const body = parse(linkJiraTicketSchema, { ticketKey: 'PI-1' })
+    expect(body.ticketKey).toBe('PI-1')
+    expect(body.goalQuantity).toBeUndefined()
+    expect(body.templateId).toBeUndefined()
+  })
+
+  it('jiraPushSchema output shape matches route usage', () => {
+    const body = parse(jiraPushSchema, { jobId: 'job_1' })
+    expect(body.jobId).toBe('job_1')
+  })
+})
+
+// ── Schema rejection tests (invalid payloads must fail) ──
+
+describe('Schema rejection — invalid payloads are rejected', () => {
+  it('createJobSchema rejects empty name', () => {
+    expect(createJobSchema.safeParse({ name: '', goalQuantity: 10 }).success).toBe(false)
+  })
+
+  it('createJobSchema rejects zero goalQuantity', () => {
+    expect(createJobSchema.safeParse({ name: 'X', goalQuantity: 0 }).success).toBe(false)
+  })
+
+  it('createJobSchema rejects negative goalQuantity', () => {
+    expect(createJobSchema.safeParse({ name: 'X', goalQuantity: -1 }).success).toBe(false)
+  })
+
+  it('createJobSchema rejects fractional goalQuantity', () => {
+    expect(createJobSchema.safeParse({ name: 'X', goalQuantity: 1.5 }).success).toBe(false)
+  })
+
+  it('createPathSchema rejects empty steps array', () => {
+    expect(createPathSchema.safeParse({ jobId: 'j', name: 'P', goalQuantity: 1, steps: [] }).success).toBe(false)
+  })
+
+  it('scrapPartSchema rejects invalid reason', () => {
+    expect(scrapPartSchema.safeParse({ reason: 'invalid_reason' }).success).toBe(false)
+  })
+
+  it('createCertSchema rejects invalid type', () => {
+    expect(createCertSchema.safeParse({ type: 'invalid', name: 'X' }).success).toBe(false)
+  })
+
+  it('batchAttachCertSchema rejects empty partIds', () => {
+    expect(batchAttachCertSchema.safeParse({ certId: 'c', partIds: [] }).success).toBe(false)
+  })
+
+  it('loginSchema rejects non-4-digit pin', () => {
+    expect(loginSchema.safeParse({ username: 'u', pin: '123' }).success).toBe(false)
+    expect(loginSchema.safeParse({ username: 'u', pin: '12345' }).success).toBe(false)
+    expect(loginSchema.safeParse({ username: 'u', pin: 'abcd' }).success).toBe(false)
+  })
+
+  it('createNoteSchema rejects empty partIds', () => {
+    expect(createNoteSchema.safeParse({
+      jobId: 'j', pathId: 'p', stepId: 's', partIds: [], text: 'note',
+    }).success).toBe(false)
+  })
+
+  it('createNoteSchema rejects empty text', () => {
+    expect(createNoteSchema.safeParse({
+      jobId: 'j', pathId: 'p', stepId: 's', partIds: ['p1'], text: '',
+    }).success).toBe(false)
+  })
+
+  it('addLibraryEntrySchema rejects empty name', () => {
+    expect(addLibraryEntrySchema.safeParse({ name: '' }).success).toBe(false)
+  })
+
+  it('createOverrideSchema rejects missing both partIds and serialIds', () => {
+    expect(createOverrideSchema.safeParse({ stepId: 's', reason: 'r' }).success).toBe(false)
+  })
+
+  it('updateStepConfigSchema rejects empty object', () => {
+    expect(updateStepConfigSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('batchPathOperationsSchema rejects all-empty operations', () => {
+    expect(batchPathOperationsSchema.safeParse({ create: [], update: [], delete: [] }).success).toBe(false)
   })
 })

--- a/tests/unit/schemas/schemaServiceContract.test.ts
+++ b/tests/unit/schemas/schemaServiceContract.test.ts
@@ -197,19 +197,36 @@ describe('Cert schemas → certService', () => {
     expect(cert.metadata).toEqual({ temperature: 1200, duration: '2h' })
   })
 
-  it('batchAttachCertSchema output is accepted by certService.batchAttachCert', () => {
-    // Verify schema output shape matches BatchAttachCertInput (minus userId which route adds)
-    const body = parse(batchAttachCertSchema, {
-      certId: 'cert_123',
-      partIds: ['part_1', 'part_2'],
+  it('batchAttachCertSchema output is accepted by certService.batchAttachCertWithSteps', () => {
+    const cert = ctx.certService.createCert({ type: 'material', name: 'Batch Cert' })
+    const job = ctx.jobService.createJob({ name: 'Cert Job', goalQuantity: 10 })
+    const path = ctx.pathService.createPath({
+      jobId: job.id,
+      name: 'Route',
+      goalQuantity: 10,
+      steps: [{ name: 'S1' }],
     })
-    // Schema output must have certId and partIds — the route adds userId
-    expect(body).toEqual({ certId: 'cert_123', partIds: ['part_1', 'part_2'] })
-    // Verify the spread pattern used in the route handler produces a valid service input
-    const serviceInput = { ...body, userId: 'user_1' }
-    expect(serviceInput).toHaveProperty('certId')
-    expect(serviceInput).toHaveProperty('partIds')
-    expect(serviceInput).toHaveProperty('userId')
+    const parts = ctx.partService.batchCreateParts(
+      { jobId: job.id, pathId: path.id, quantity: 2 },
+      'user_1',
+    )
+    const body = parse(batchAttachCertSchema, {
+      certId: cert.id,
+      partIds: parts.map(p => p.id),
+    })
+    // Route handler resolves each part's current step, then calls batchAttachCertWithSteps
+    const attachments = ctx.certService.batchAttachCertWithSteps({
+      certId: body.certId,
+      attachments: parts.map(p => ({
+        partId: p.id,
+        stepId: p.currentStepId!,
+        jobId: p.jobId,
+        pathId: p.pathId,
+      })),
+      userId: 'user_1',
+    })
+    expect(attachments).toHaveLength(2)
+    expect(attachments[0].stepId).toBe(path.steps[0].id)
   })
 })
 

--- a/tests/unit/services/certService.test.ts
+++ b/tests/unit/services/certService.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createCertService } from '../../../server/services/certService'
 import { NotFoundError, ValidationError } from '../../../server/utils/errors'
 import type { CertRepository } from '../../../server/repositories/interfaces/certRepository'
+import type { PartRepository } from '../../../server/repositories/interfaces/partRepository'
+import type { PathRepository } from '../../../server/repositories/interfaces/pathRepository'
 import type { AuditService } from '../../../server/services/auditService'
-import type { Certificate, CertAttachment } from '../../../server/types/domain'
+import type { Certificate, CertAttachment, Part } from '../../../server/types/domain'
 
 function makeCert(overrides: Partial<Certificate> = {}): Certificate {
   return {
@@ -11,6 +13,20 @@ function makeCert(overrides: Partial<Certificate> = {}): Certificate {
     type: 'material',
     name: 'Steel Cert',
     createdAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makePart(overrides: Partial<Part> = {}): Part {
+  return {
+    id: 'part_00001',
+    jobId: 'job_1',
+    pathId: 'path_1',
+    currentStepId: 'step_1',
+    status: 'in_progress',
+    forceCompleted: false,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
     ...overrides,
   }
 }
@@ -46,6 +62,35 @@ function createMockCertRepo(): CertRepository {
   }
 }
 
+function createMockPartRepo(parts: Part[] = []): PartRepository {
+  const partsMap = new Map(parts.map(p => [p.id, p]))
+  return {
+    getById: vi.fn((id: string) => partsMap.get(id) ?? null),
+    create: vi.fn(),
+    list: vi.fn(() => [...partsMap.values()]),
+    update: vi.fn(),
+    delete: vi.fn(),
+    listByJobId: vi.fn(() => []),
+    listByPathId: vi.fn(() => []),
+    countByJobId: vi.fn(() => 0),
+    countCompletedByJobId: vi.fn(() => 0),
+    countScrappedByJobId: vi.fn(() => 0),
+    countsByJob: vi.fn(() => new Map()),
+    batchCreate: vi.fn(() => []),
+  } as any
+}
+
+function createMockPathRepo(): PathRepository {
+  return {
+    getById: vi.fn(() => null),
+    create: vi.fn(),
+    list: vi.fn(() => []),
+    update: vi.fn(),
+    delete: vi.fn(),
+    listByJobId: vi.fn(() => []),
+  } as any
+}
+
 function createMockAuditService(): AuditService {
   return {
     recordCertAttachment: vi.fn(() => ({}) as any),
@@ -61,13 +106,17 @@ function createMockAuditService(): AuditService {
 
 describe('CertService', () => {
   let certRepo: CertRepository
+  let partRepo: PartRepository
+  let pathRepo: PathRepository
   let auditService: AuditService
   let service: ReturnType<typeof createCertService>
 
   beforeEach(() => {
     certRepo = createMockCertRepo()
+    partRepo = createMockPartRepo()
+    pathRepo = createMockPathRepo()
     auditService = createMockAuditService()
-    service = createCertService({ certs: certRepo }, auditService)
+    service = createCertService({ certs: certRepo, parts: partRepo, paths: pathRepo }, auditService)
   })
 
   describe('createCert', () => {
@@ -180,8 +229,15 @@ describe('CertService', () => {
   })
 
   describe('batchAttachCert', () => {
-    it('attaches cert to multiple parts and records audit for each', () => {
+    it('resolves step IDs from parts and attaches cert to each', () => {
       certRepo.create(makeCert({ id: 'cert_1' }))
+      const parts = [
+        makePart({ id: 'part_00001', currentStepId: 'step_1' }),
+        makePart({ id: 'part_00002', currentStepId: 'step_2' }),
+        makePart({ id: 'part_00003', currentStepId: 'step_1' }),
+      ]
+      partRepo = createMockPartRepo(parts)
+      service = createCertService({ certs: certRepo, parts: partRepo, paths: pathRepo }, auditService)
 
       const result = service.batchAttachCert({
         certId: 'cert_1',
@@ -190,11 +246,17 @@ describe('CertService', () => {
       })
 
       expect(result).toHaveLength(3)
+      expect(result[0].stepId).toBe('step_1')
+      expect(result[1].stepId).toBe('step_2')
+      expect(result[2].stepId).toBe('step_1')
       expect(certRepo.batchAttach).toHaveBeenCalledTimes(1)
       expect(auditService.recordCertAttachment).toHaveBeenCalledTimes(3)
     })
 
     it('throws NotFoundError when cert does not exist', () => {
+      partRepo = createMockPartRepo([makePart()])
+      service = createCertService({ certs: certRepo, parts: partRepo, paths: pathRepo }, auditService)
+
       expect(() =>
         service.batchAttachCert({
           certId: 'nonexistent',
@@ -202,6 +264,33 @@ describe('CertService', () => {
           userId: 'user_1',
         }),
       ).toThrow(NotFoundError)
+    })
+
+    it('throws NotFoundError when a part does not exist', () => {
+      certRepo.create(makeCert({ id: 'cert_1' }))
+      // partRepo has no parts
+      expect(() =>
+        service.batchAttachCert({
+          certId: 'cert_1',
+          partIds: ['nonexistent_part'],
+          userId: 'user_1',
+        }),
+      ).toThrow(NotFoundError)
+    })
+
+    it('throws ValidationError when a part is already completed', () => {
+      certRepo.create(makeCert({ id: 'cert_1' }))
+      const completedPart = makePart({ id: 'part_done', currentStepId: null, status: 'completed' })
+      partRepo = createMockPartRepo([completedPart])
+      service = createCertService({ certs: certRepo, parts: partRepo, paths: pathRepo }, auditService)
+
+      expect(() =>
+        service.batchAttachCert({
+          certId: 'cert_1',
+          partIds: ['part_done'],
+          userId: 'user_1',
+        }),
+      ).toThrow(ValidationError)
     })
   })
 

--- a/tests/unit/services/jiraService.test.ts
+++ b/tests/unit/services/jiraService.test.ts
@@ -433,7 +433,7 @@ describe('JiraService', () => {
         },
       })
       partService = createPartService({ parts: partsRepo, paths: pathsRepo, certs: certsRepo }, auditService, partIdGenerator)
-      certService = createCertService({ certs: certsRepo }, auditService)
+      certService = createCertService({ certs: certsRepo, parts: partsRepo, paths: pathsRepo }, auditService)
       noteService = createNoteService({ notes: notesRepo }, auditService)
     })
 

--- a/tests/unit/utils/services.test.ts
+++ b/tests/unit/utils/services.test.ts
@@ -81,7 +81,7 @@ describe('Service Factory (getServices pattern)', () => {
       auditService,
       partIdGenerator,
     )
-    const certService = createCertService({ certs: repos.certs }, auditService)
+    const certService = createCertService({ certs: repos.certs, parts: repos.parts, paths: repos.paths }, auditService)
     const noteService = createNoteService({ notes: repos.notes }, auditService)
     const settingsService = createSettingsService({ settings: repos.settings }, {
       jiraBaseUrl: 'https://jira.example.com',


### PR DESCRIPTION
Fixes #171

## Summary

Adds Zod schema validation to all 17 POST/PUT/PATCH routes that were using raw `readBody(event)` without validation. Each route now uses `parseBody(event, schema)` and includes `requestBody: zodRequestBody(schema)` in `defineRouteMeta` for automatic OpenAPI documentation.

## Routes updated

### Jobs
- `POST /api/jobs` — `createJobSchema`
- `PUT /api/jobs/:id` — `updateJobSchema`
- `PATCH /api/jobs/priorities` — `updatePrioritiesSchema`

### Parts
- `POST /api/parts` — `createPartsSchema`
- `POST /api/parts/:id/scrap` — `scrapPartSchema`
- `POST /api/parts/:id/force-complete` — `forceCompleteSchema`
- `POST /api/parts/:id/advance-to` — `advanceToStepSchema`
- `POST /api/parts/:id/overrides` — `createOverrideSchema`
- `POST /api/parts/:id/attach-cert` — `attachCertSchema`

### Certificates
- `POST /api/certs` — `createCertSchema`
- `POST /api/certs/batch-attach` — `batchAttachCertSchema`

### Templates
- `POST /api/templates` — `createTemplateSchema`
- `PUT /api/templates/:id` — `updateTemplateSchema`
- `POST /api/templates/:id/apply` — `applyTemplateSchema`

### Users
- `POST /api/users` — `createUserSchema`
- `PUT /api/users/:id` — `updateUserSchema`

### Settings
- `PUT /api/settings` — `updateSettingsSchema`

## New schema files
- `server/schemas/jobSchemas.ts`
- `server/schemas/certSchemas.ts`
- `server/schemas/templateSchemas.ts`
- `server/schemas/userSchemas.ts`
- `server/schemas/settingsSchemas.ts`

## Extended
- `server/schemas/partSchemas.ts` — 6 new schemas added

## Verification
- Lint: ✅
- Typecheck: ✅
- Tests: 265 files, 1765 tests passing ✅